### PR TITLE
Improve scheduled function module: replace versioning with hash-based naming and add retry configuration

### DIFF
--- a/terraform/modules/scheduled-function/main.tf
+++ b/terraform/modules/scheduled-function/main.tf
@@ -31,6 +31,7 @@ resource "google_storage_bucket" "function_bucket" {
   name                        = "${var.function_name}-source-${var.project_id}"
   location                    = var.region
   uniform_bucket_level_access = true
+  force_destroy               = true
 
   # Enable versioned objects
   versioning {
@@ -52,7 +53,7 @@ resource "google_storage_bucket" "function_bucket" {
 data "archive_file" "function_archive" {
   type        = "zip"
   output_path = "${path.module}/${var.function_name}-function.zip"
-  source_dir  = var.source_dir
+  source_dir  = abspath(var.source_dir)
   excludes    = var.excludes
 }
 
@@ -146,6 +147,6 @@ resource "google_cloudfunctions2_function" "function" {
     trigger_region = var.region
     event_type     = "google.cloud.pubsub.topic.v1.messagePublished"
     pubsub_topic   = google_pubsub_topic.function_topic.id
-    retry_policy   = "RETRY_POLICY_RETRY"
+    retry_policy   = var.retries_enabled ? "RETRY_POLICY_RETRY" : "RETRY_POLICY_DO_NOT_RETRY"
   }
 } 

--- a/terraform/modules/scheduled-function/main.tf
+++ b/terraform/modules/scheduled-function/main.tf
@@ -32,21 +32,6 @@ resource "google_storage_bucket" "function_bucket" {
   location                    = var.region
   uniform_bucket_level_access = true
   force_destroy               = true
-
-  # Enable versioned objects
-  versioning {
-    enabled = true
-  }
-
-  # Keep only the 3 most recent versions of each object
-  lifecycle_rule {
-    condition {
-      num_newer_versions = 3
-    }
-    action {
-      type = "Delete"
-    }
-  }
 }
 
 # Create function source archive
@@ -58,8 +43,12 @@ data "archive_file" "function_archive" {
 }
 
 # Upload function archive to storage bucket
+# The object name includes the source code hash, ensuring:
+# 1. Cloud Function redeploys when source code changes (new hash = new object name)
+# 2. Terraform automatically deletes old zip files when hash changes (resource replacement)
+# 3. No manual cleanup or lifecycle rules needed - Terraform handles it
 resource "google_storage_bucket_object" "function_archive" {
-  name   = "${var.function_name}-function.zip"
+  name   = "${var.function_name}-function-${data.archive_file.function_archive.output_sha}.zip"
   bucket = google_storage_bucket.function_bucket.name
   source = data.archive_file.function_archive.output_path
 }

--- a/terraform/modules/scheduled-function/variables.tf
+++ b/terraform/modules/scheduled-function/variables.tf
@@ -97,6 +97,12 @@ variable "min_instance_count" {
   default     = 1
 }
 
+variable "retries_enabled" {
+  description = "Whether the retry policy is set to `RETRY_POLICY_RETRY`"
+  type        = bool
+  default     = false
+}
+
 # Environment variables
 variable "environment_variables" {
   description = "Environment variables for the Cloud Function"


### PR DESCRIPTION
## Summary:
This PR improves the scheduled function Terraform module with several key enhancements:

**Storage Bucket Improvements:**
- Removed object versioning and lifecycle rules in favor of hash-based object naming
- Added `force_destroy = true` to allow bucket deletion during terraform destroy
- This simplifies bucket management and reduces storage costs

**Function Archive Management:**
- Changed object naming to include source code hash: `${function_name}-function-${hash}.zip`
- This ensures Cloud Functions redeploy when source code changes (new hash = new object name)
- Terraform automatically handles cleanup of old zip files when hash changes
- No manual lifecycle rules needed - Terraform's resource replacement handles it

**Source Directory Handling:**
- Added `abspath()` wrapper around `var.source_dir` for more reliable path resolution

**Retry Policy Configuration:**
- Added new `retries_enabled` variable (default: false) to control retry behavior
- Made retry policy configurable: `RETRY_POLICY_RETRY` vs `RETRY_POLICY_DO_NOT_RETRY`
- This provides better control over function execution behavior

These changes improve resource management, reduce storage costs, and provide better configurability for the scheduled function module.

## Test plan:
1. Deploy a new scheduled function using this updated module
2. Verify function deploys correctly with hash-based naming
3. Test source code changes trigger redeployment (new hash generated)
4. Verify retry policy works correctly with both enabled/disabled settings
5. Test terraform destroy completes successfully with force_destroy
6. Verify no orphaned zip files remain in storage bucket