### PR TITLE
Add Cloud Run Jobs Support to Scheduled Function Module

### DIFF
--- a/terraform/modules/scheduled-function/README.md
+++ b/terraform/modules/scheduled-function/README.md
@@ -18,7 +18,7 @@ Creates a complete scheduled setup:
 ### Cloud Function Example
 ```hcl
 module "my_daily_task" {
-  source = "git::https://github.com/Khan/terraform-scheduled-function-module.git?ref=v1.0.0"
+  source = "git::https://github.com/Khan/terraform-modules.git//terraform/modules/scheduled-function?ref=v1.0.0"
 
   function_name      = "my-daily-task"
   execution_type     = "function"  # Default, can be omitted
@@ -46,7 +46,7 @@ module "my_daily_task" {
 ### Cloud Run Job Example
 ```hcl
 module "my_data_processor" {
-  source = "git::https://github.com/Khan/terraform-scheduled-function-module.git?ref=v1.0.0"
+  source = "git::https://github.com/Khan/terraform-modules.git//terraform/modules/scheduled-function?ref=v1.0.0"
 
   function_name      = "my-data-processor"
   execution_type     = "job"
@@ -117,19 +117,25 @@ Each example includes:
 | **Container** | Runtime-based | Custom container images |
 | **Parallelism** | Multiple instances | Configurable parallelism |
 
+### Cost Considerations
+
+**Pricing is extremely similar** between Cloud Functions (2nd gen) and Cloud Run Jobs since both are billed as Cloud Run services. See the [official Cloud Run pricing page](https://cloud.google.com/run/pricing) for current rates.
+
+*Note: Both execution types use the same pricing model, so cost should not be the primary factor in your decision.*
+
 ## Cross-Repository Usage
 
 ### Use Everywhere
 ```hcl
 # Production: Pin to specific version
 module "backup" {
-  source = "git::https://github.com/YourOrg/terraform-scheduled-function-module.git?ref=v1.0.0"
+  source = "git::https://github.com/Khan/terraform-modules.git//terraform/modules/scheduled-function?ref=v1.0.0"
   # ... config
 }
 
 # Development: Use latest
 module "test_function" {
-  source = "git::https://github.com/YourOrg/terraform-scheduled-function-module.git"
+  source = "git::https://github.com/Khan/terraform-modules.git//terraform/modules/scheduled-function"
   # ... config
 }
 ```
@@ -139,7 +145,7 @@ module "test_function" {
 ### Multiple Functions
 ```hcl
 module "daily_backup" {
-  source = "git::https://github.com/YourOrg/terraform-scheduled-function-module.git?ref=v1.0.0"
+  source = "git::https://github.com/Khan/terraform-modules.git//terraform/modules/scheduled-function?ref=v1.0.0"
   
   function_name = "daily-backup"
   schedule      = "0 2 * * *"  # 2 AM daily
@@ -149,7 +155,7 @@ module "daily_backup" {
 }
 
 module "weekly_reports" {
-  source = "git::https://github.com/YourOrg/terraform-scheduled-function-module.git?ref=v1.0.0"
+  source = "git::https://github.com/Khan/terraform-modules.git//terraform/modules/scheduled-function?ref=v1.0.0"
   
   function_name = "weekly-reports"
   schedule      = "0 9 * * 1"  # Monday 9 AM
@@ -163,7 +169,7 @@ module "weekly_reports" {
 ### Advanced Configuration
 ```hcl
 module "data_processor" {
-  source = "git::https://github.com/YourOrg/terraform-scheduled-function-module.git?ref=v1.0.0"
+  source = "git::https://github.com/Khan/terraform-modules.git//terraform/modules/scheduled-function?ref=v1.0.0"
   
   function_name      = "data-processor"
   project_id         = var.project_id

--- a/terraform/modules/scheduled-function/README.md
+++ b/terraform/modules/scheduled-function/README.md
@@ -60,7 +60,7 @@ module "my_data_processor" {
   # Job-specific configuration
   job_cpu    = "2000m"
   job_memory = "2Gi"
-  job_timeout = 7200  # 2 hours
+  job_timeout = "7200s"  # 2 hours
   job_image  = "gcr.io/my-gcp-project/my-data-processor:latest"
 
   environment_variables = {
@@ -217,7 +217,7 @@ module "data_processor" {
 ### Cloud Run Job specific (when `execution_type = "job"`)
 - `job_cpu` - CPU allocation (e.g., "1000m", "2") ("1000m")
 - `job_memory` - Memory allocation (e.g., "512Mi", "2Gi") ("512Mi")
-- `job_timeout` - Timeout in seconds (3600)
+- `job_timeout` - Timeout duration (e.g., "3600s", "1h", "2h30m") ("3600s")
 - `job_parallelism` - Number of parallel executions (1)
 - `job_task_count` - Number of tasks to run (1)
 - `job_command` - Command to run (["python", "main.py"])

--- a/terraform/modules/scheduled-function/README.md
+++ b/terraform/modules/scheduled-function/README.md
@@ -1,13 +1,13 @@
 # terraform-scheduled-function-module
 
-A reusable Terraform module for scheduled Google Cloud Functions.
+A reusable Terraform module for scheduled Google Cloud Functions and Cloud Run Jobs.
 
 ## Features
 
-Creates a complete scheduled function setup:
-- Cloud Function (2nd gen) with configurable runtime
+Creates a complete scheduled setup:
+- **Cloud Function (2nd gen)** OR **Cloud Run Job** with configurable runtime
 - Cloud Scheduler with cron-based scheduling  
-- PubSub topic for reliable triggering
+- PubSub topic for reliable triggering (Cloud Functions only)
 - Service account with least-privilege permissions
 - Storage bucket with lifecycle management
 - Secret Manager IAM bindings
@@ -15,11 +15,13 @@ Creates a complete scheduled function setup:
 
 ## Quick Start
 
+### Cloud Function Example
 ```hcl
 module "my_daily_task" {
   source = "git::https://github.com/Khan/terraform-scheduled-function-module.git?ref=v1.0.0"
 
   function_name      = "my-daily-task"
+  execution_type     = "function"  # Default, can be omitted
   project_id         = "my-gcp-project"
   secrets_project_id = "my-secrets-gcp-project"
   source_dir         = "./functions/my-task"
@@ -41,16 +43,79 @@ module "my_daily_task" {
 }
 ```
 
+### Cloud Run Job Example
+```hcl
+module "my_data_processor" {
+  source = "git::https://github.com/Khan/terraform-scheduled-function-module.git?ref=v1.0.0"
+
+  function_name      = "my-data-processor"
+  execution_type     = "job"
+  project_id         = "my-gcp-project"
+  secrets_project_id = "my-secrets-gcp-project"
+  source_dir         = "./jobs/data-processor"
+  main_file          = "processor.py"
+  schedule           = "0 2 * * *"  # 2 AM daily
+  description        = "Daily data processing job"
+
+  # Job-specific configuration
+  job_cpu    = "2000m"
+  job_memory = "2Gi"
+  job_timeout = "7200"  # 2 hours
+  job_image  = "gcr.io/my-gcp-project/my-data-processor:latest"
+
+  environment_variables = {
+    ENV = "production"
+  }
+
+  secrets = [
+    {
+      env_var_name = "DATABASE_URL"
+      secret_id    = "database-connection"
+      version      = "latest"
+    }
+  ]
+}
+```
+
 ## Examples
 
 Complete working examples are available in the [`examples/`](./examples/) directory:
 
-- **[`simple-function/`](./examples/simple-function/)** - Basic scheduled function with minimal configuration
+- **[`simple-function/`](./examples/simple-function/)** - Basic scheduled Cloud Function with minimal configuration
+- **[`simple-job/`](./examples/simple-job/)** - Basic scheduled Cloud Run Job with minimal configuration
 
 Each example includes:
 - Complete Terraform configuration
-- Sample function code with `requirements.txt`
+- Sample code with `requirements.txt`
 - Documentation on how to deploy and test
+
+## Cloud Functions vs Cloud Run Jobs
+
+### When to use Cloud Functions (`execution_type = "function"`)
+- **Short-running tasks** (up to 60 minutes)
+- **Event-driven workloads** (PubSub, HTTP, etc.)
+- **Serverless scaling** (0 to many instances)
+- **Simple Python/Node.js/Go applications**
+- **Cost-effective for sporadic workloads**
+
+### When to use Cloud Run Jobs (`execution_type = "job"`)
+- **Long-running batch processes** (up to 24 hours)
+- **Resource-intensive workloads** (high CPU/memory)
+- **Scheduled batch jobs** (ETL, data processing, reports)
+- **Container-based applications**
+- **Parallel processing** (multiple tasks)
+- **Custom runtimes** (any container image)
+
+### Key Differences
+
+| Feature | Cloud Functions | Cloud Run Jobs |
+|---------|----------------|----------------|
+| **Max Runtime** | 60 minutes | 24 hours |
+| **Triggering** | PubSub, HTTP, etc. | HTTP API calls |
+| **Scaling** | Auto-scaling | Manual execution |
+| **Resources** | Limited CPU/memory | Configurable CPU/memory |
+| **Container** | Runtime-based | Custom container images |
+| **Parallelism** | Multiple instances | Configurable parallelism |
 
 ## Cross-Repository Usage
 
@@ -132,28 +197,43 @@ module "data_processor" {
 ## Requirements & Inputs
 
 ### Required
-- `function_name` - Unique name for your function
+- `function_name` - Unique name for your function/job
 - `project_id` - GCP project for resources
 - `secrets_project_id` - GCP project containing secrets
-- `source_dir` - Path to function code
+- `source_dir` - Path to function/job code
 - `main_file` - Python file name (e.g., "main.py"), relative to `source_dir`.
 - `schedule` - Cron expression (e.g., "0 9 * * 1-5")
-- `description` - Function description
+- `description` - Function/job description
 
 ### Optional (with defaults)
+- `execution_type` - "function" or "job" ("function")
 - `region` - GCP region ("us-central1")
 - `runtime` - Function runtime ("python311")
-- `memory` - Memory allocation ("2048M")
-- `timeout_seconds` - Timeout (60)
+- `memory` - Memory allocation for functions ("2048M")
+- `timeout_seconds` - Timeout for functions (60)
 - `environment_variables` - Environment vars ({})
 - `secrets` - Secret Manager secrets ([])
 
+### Cloud Run Job specific (when `execution_type = "job"`)
+- `job_cpu` - CPU allocation (e.g., "1000m", "2") ("1000m")
+- `job_memory` - Memory allocation (e.g., "512Mi", "2Gi") ("512Mi")
+- `job_timeout` - Timeout in seconds ("3600")
+- `job_parallelism` - Number of parallel executions (1)
+- `job_task_count` - Number of tasks to run (1)
+- `job_command` - Command to run (["python", "main.py"])
+- `job_args` - Command arguments ([])
+- `job_image` - Container image URL (required)
+
 ## Outputs
 
-- `function_name` - Name of deployed function
-- `function_url` - Function URL
-- `service_account_email` - Function service account
+- `function_name` - Name of deployed function (when `execution_type = "function"`)
+- `job_name` - Name of deployed job (when `execution_type = "job"`)
+- `function_url` - Function URL (when `execution_type = "function"`)
+- `service_account_email` - Service account email
 - `scheduler_job_name` - Scheduler job name
+- `pubsub_topic_name` - PubSub topic name (when `execution_type = "function"`)
+- `storage_bucket_name` - Storage bucket name
+- `execution_type` - The execution type used
 
 ## Repository Structure
 
@@ -168,12 +248,17 @@ your-app-repo/
 │   └── reports/
 │       ├── main.py
 │       └── requirements.txt
+├── jobs/
+│   └── data-processor/
+│       ├── processor.py
+│       ├── requirements.txt
+│       └── Dockerfile
 └── README.md
 ```
 
-## Function Code Structure
+## Code Structure
 
-### Required Files
+### Cloud Functions
 
 Your source directory must contain:
 
@@ -183,7 +268,7 @@ functions/my-task/
 └── requirements.txt     # Python dependencies (if needed)
 ```
 
-### Python Function Code
+#### Python Function Code
 
 ```python
 # functions/my-task/main.py
@@ -196,9 +281,71 @@ def main(cloud_event):
     return "Success"
 ```
 
+### Cloud Run Jobs
+
+Your source directory should contain:
+
+```
+jobs/my-job/
+├── processor.py         # Main job script
+├── requirements.txt     # Python dependencies
+└── Dockerfile          # Container definition
+```
+
+#### Python Job Code
+
+```python
+# jobs/my-job/processor.py
+#!/usr/bin/env python3
+import os
+import sys
+import logging
+
+def main():
+    """Main function for the Cloud Run Job."""
+    logging.info("Starting job...")
+    # Your job logic here
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+#### Dockerfile Example
+
+```dockerfile
+# jobs/my-job/Dockerfile
+FROM python:3.11-slim
+
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+
+COPY . .
+CMD ["python", "processor.py"]
+```
+
 ### Dependencies
 
-If your function uses external packages, include a `requirements.txt` file. Cloud Functions automatically install dependencies from `requirements.txt` during deployment. No local installation is needed - the module simply packages your source code and lets Cloud Functions handle dependency management.
+For both Cloud Functions and Cloud Run Jobs, include a `requirements.txt` file if your code uses external packages. Cloud Functions automatically install dependencies during deployment, while Cloud Run Jobs require a Dockerfile to build the container image.
+
+### Building and Pushing Container Images for Cloud Run Jobs
+
+Before deploying a Cloud Run Job, you need to build and push your container image:
+
+```bash
+# Build the image
+docker build -t gcr.io/YOUR_PROJECT_ID/YOUR_JOB_NAME:latest ./jobs/your-job
+
+# Push to Container Registry
+docker push gcr.io/YOUR_PROJECT_ID/YOUR_JOB_NAME:latest
+```
+
+Or use Cloud Build:
+
+```bash
+gcloud builds submit --tag gcr.io/YOUR_PROJECT_ID/YOUR_JOB_NAME:latest ./jobs/your-job
+```
 
 ## Common Cron Patterns
 

--- a/terraform/modules/scheduled-function/README.md
+++ b/terraform/modules/scheduled-function/README.md
@@ -60,7 +60,7 @@ module "my_data_processor" {
   # Job-specific configuration
   job_cpu    = "2000m"
   job_memory = "2Gi"
-  job_timeout = "7200"  # 2 hours
+  job_timeout = 7200  # 2 hours
   job_image  = "gcr.io/my-gcp-project/my-data-processor:latest"
 
   environment_variables = {
@@ -217,7 +217,7 @@ module "data_processor" {
 ### Cloud Run Job specific (when `execution_type = "job"`)
 - `job_cpu` - CPU allocation (e.g., "1000m", "2") ("1000m")
 - `job_memory` - Memory allocation (e.g., "512Mi", "2Gi") ("512Mi")
-- `job_timeout` - Timeout in seconds ("3600")
+- `job_timeout` - Timeout in seconds (3600)
 - `job_parallelism` - Number of parallel executions (1)
 - `job_task_count` - Number of tasks to run (1)
 - `job_command` - Command to run (["python", "main.py"])

--- a/terraform/modules/scheduled-function/examples/simple-function/main.tf
+++ b/terraform/modules/scheduled-function/examples/simple-function/main.tf
@@ -25,7 +25,7 @@ provider "google" {
 # Simple daily function example
 module "daily_health_check" {
   # When used from another repository, this would be:
-  # source = "git::https://github.com/Khan/terraform-scheduled-function-module.git?ref=v1.0.0"
+  # source = "git::https://github.com/Khan/terraform-modules.git//terraform/modules/scheduled-function?ref=v1.0.0"
   source = "../.."
 
   function_name      = "daily-health-check"

--- a/terraform/modules/scheduled-function/examples/simple-job/README.md
+++ b/terraform/modules/scheduled-function/examples/simple-job/README.md
@@ -48,7 +48,7 @@ module "daily_data_processor" {
   # Job-specific configuration
   job_cpu    = "2000m"        # 2 CPU cores
   job_memory = "2Gi"          # 2 GB memory
-  job_timeout = "7200"        # 2 hours timeout
+  job_timeout = 7200        # 2 hours timeout
   
   # Container image (build and push separately)
   job_image = "gcr.io/YOUR_PROJECT_ID/daily-data-processor:latest"

--- a/terraform/modules/scheduled-function/examples/simple-job/README.md
+++ b/terraform/modules/scheduled-function/examples/simple-job/README.md
@@ -1,0 +1,79 @@
+# Simple Cloud Run Job Example
+
+This example demonstrates how to use the scheduled-function module to create a Cloud Run Job that runs on a schedule.
+
+## What this example creates
+
+- A Cloud Run Job that processes data daily at 2 AM
+- Cloud Scheduler job to trigger the Cloud Run Job
+- Service account with appropriate permissions
+- Storage bucket for job source code
+- Secret Manager IAM bindings
+
+## Key differences from Cloud Functions
+
+1. **Execution Type**: Set `execution_type = "job"` to create a Cloud Run Job instead of a Cloud Function
+2. **Triggering**: Cloud Run Jobs are triggered via HTTP calls to the Cloud Run Jobs API (not PubSub)
+3. **Resource Configuration**: Use `job_cpu`, `job_memory`, `job_timeout` instead of function-specific variables
+4. **Command**: Specify the command to run with `job_command` and `job_args`
+
+## Usage
+
+1. Set your project variables:
+   ```bash
+   export TF_VAR_project_id="your-gcp-project"
+   export TF_VAR_secrets_project_id="your-secrets-project"
+   ```
+
+2. Initialize and apply:
+   ```bash
+   terraform init
+   terraform plan
+   terraform apply
+   ```
+
+3. The job will be scheduled to run daily at 2 AM UTC.
+
+## Configuration
+
+The main configuration differences for Cloud Run Jobs:
+
+```hcl
+module "daily_data_processor" {
+  source = "../.."
+
+  function_name      = "daily-data-processor"
+  execution_type     = "job"  # This creates a Cloud Run Job
+  
+  # Job-specific configuration
+  job_cpu    = "2000m"        # 2 CPU cores
+  job_memory = "2Gi"          # 2 GB memory
+  job_timeout = "7200"        # 2 hours timeout
+  
+  # Container image (build and push separately)
+  job_image = "gcr.io/YOUR_PROJECT_ID/daily-data-processor:latest"
+  
+  # Command to run
+  job_command = ["python", "processor.py"]
+  job_args    = []            # Additional arguments if needed
+  
+  # ... other configuration
+}
+```
+
+## Job Code
+
+The job code in `job-code/processor.py` is a simple Python script that:
+- Logs the start of processing
+- Accesses environment variables (including secrets)
+- Simulates data processing work
+- Returns appropriate exit codes
+
+## Important Notes
+
+- **Container Image Required**: You need to build and push a Docker image to Container Registry or Artifact Registry before deploying.
+- **Dockerfile**: Include a `Dockerfile` in your source directory to build the container image.
+- **Manual Build/Push**: The module creates the job definition but doesn't handle container image building/pushing.
+- **Build Process**: Use `docker build` and `docker push` or `gcloud builds submit` to create your container image.
+- Jobs are triggered via HTTP calls to the Cloud Run Jobs API, not via PubSub like Cloud Functions.
+- Jobs can run for longer periods and have more resources than Cloud Functions.

--- a/terraform/modules/scheduled-function/examples/simple-job/README.md
+++ b/terraform/modules/scheduled-function/examples/simple-job/README.md
@@ -48,7 +48,7 @@ module "daily_data_processor" {
   # Job-specific configuration
   job_cpu    = "2000m"        # 2 CPU cores
   job_memory = "2Gi"          # 2 GB memory
-  job_timeout = 7200        # 2 hours timeout
+  job_timeout = "7200s"        # 2 hours timeout
   
   # Container image (build and push separately)
   job_image = "gcr.io/YOUR_PROJECT_ID/daily-data-processor:latest"

--- a/terraform/modules/scheduled-function/examples/simple-job/job-code/Dockerfile
+++ b/terraform/modules/scheduled-function/examples/simple-job/job-code/Dockerfile
@@ -1,0 +1,20 @@
+# Dockerfile for Cloud Run Job
+FROM python:3.11-slim
+
+# Set working directory
+WORKDIR /app
+
+# Copy requirements first for better caching
+COPY requirements.txt .
+
+# Install dependencies
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY . .
+
+# Make the script executable
+RUN chmod +x processor.py
+
+# Set the default command
+CMD ["python", "processor.py"]

--- a/terraform/modules/scheduled-function/examples/simple-job/job-code/processor.py
+++ b/terraform/modules/scheduled-function/examples/simple-job/job-code/processor.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""
+Sample Cloud Run Job for data processing.
+This script demonstrates a basic job that can be scheduled to run periodically.
+"""
+
+import os
+import sys
+import logging
+from datetime import datetime
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+)
+logger = logging.getLogger(__name__)
+
+def main():
+    """Main function for the Cloud Run Job."""
+    logger.info("Starting data processing job")
+    
+    # Get environment variables
+    env = os.getenv('ENV', 'development')
+    log_level = os.getenv('LOG_LEVEL', 'INFO')
+    database_url = os.getenv('DATABASE_URL')
+    
+    logger.info(f"Environment: {env}")
+    logger.info(f"Log level: {log_level}")
+    logger.info(f"Database URL configured: {database_url is not None}")
+    
+    # Simulate data processing work
+    logger.info("Processing data...")
+    
+    # Simulate some work
+    for i in range(5):
+        logger.info(f"Processing batch {i + 1}/5")
+        # In a real job, you would do actual data processing here
+        # For example: database queries, API calls, file processing, etc.
+    
+    logger.info("Data processing completed successfully")
+    
+    # Return exit code 0 for success
+    return 0
+
+if __name__ == "__main__":
+    try:
+        exit_code = main()
+        sys.exit(exit_code)
+    except Exception as e:
+        logger.error(f"Job failed with error: {e}")
+        sys.exit(1)

--- a/terraform/modules/scheduled-function/examples/simple-job/job-code/requirements.txt
+++ b/terraform/modules/scheduled-function/examples/simple-job/job-code/requirements.txt
@@ -1,0 +1,8 @@
+# Sample requirements for the Cloud Run Job
+# Add any Python packages your job needs here
+
+# Example packages (uncomment and modify as needed):
+# requests>=2.28.0
+# pandas>=1.5.0
+# google-cloud-storage>=2.0.0
+# google-cloud-bigquery>=3.0.0

--- a/terraform/modules/scheduled-function/examples/simple-job/main.tf
+++ b/terraform/modules/scheduled-function/examples/simple-job/main.tf
@@ -1,0 +1,71 @@
+# Simple example of using the scheduled function module with Cloud Run Jobs
+# This shows the minimum configuration needed for a Cloud Run Job
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 6.0.0"
+    }
+  }
+  required_version = ">= 1.3.0"
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+provider "google" {
+  alias   = "secrets"
+  project = var.secrets_project_id
+  region  = var.region
+}
+
+# Simple daily job example
+module "daily_data_processor" {
+  # When used from another repository, this would be:
+  # source = "git::https://github.com/Khan/terraform-scheduled-function-module.git?ref=v1.0.0"
+  source = "../.."
+
+  function_name      = "daily-data-processor"
+  execution_type     = "job"
+  project_id         = var.project_id
+  secrets_project_id = var.secrets_project_id
+  source_dir         = "./job-code"
+  main_file          = "processor.py"
+  schedule           = "0 2 * * *" # 2 AM daily
+  description        = "Daily data processing job"
+
+  # Job-specific configuration
+  job_cpu    = "2000m"
+  job_memory = "2Gi"
+  job_timeout = "7200" # 2 hours
+  
+  # Container image (build and push separately)
+  job_image = "gcr.io/${var.project_id}/daily-data-processor:latest"
+
+  environment_variables = {
+    ENV       = "production"
+    LOG_LEVEL = "INFO"
+  }
+
+  secrets = [
+    {
+      env_var_name = "DATABASE_URL"
+      secret_id    = "database-connection-string"
+      version      = "latest"
+    }
+  ]
+}
+
+# Output the job details
+output "job_info" {
+  description = "Information about the deployed job"
+  value = {
+    job_name              = module.daily_data_processor.job_name
+    service_account_email = module.daily_data_processor.service_account_email
+    scheduler_job_name    = module.daily_data_processor.scheduler_job_name
+    execution_type        = module.daily_data_processor.execution_type
+  }
+}

--- a/terraform/modules/scheduled-function/examples/simple-job/main.tf
+++ b/terraform/modules/scheduled-function/examples/simple-job/main.tf
@@ -40,7 +40,7 @@ module "daily_data_processor" {
   # Job-specific configuration
   job_cpu    = "2000m"
   job_memory = "2Gi"
-  job_timeout = 7200 # 2 hours
+  job_timeout = "7200s" # 2 hours
   
   # Container image (build and push separately)
   job_image = "gcr.io/${var.project_id}/daily-data-processor:latest"

--- a/terraform/modules/scheduled-function/examples/simple-job/main.tf
+++ b/terraform/modules/scheduled-function/examples/simple-job/main.tf
@@ -25,7 +25,7 @@ provider "google" {
 # Simple daily job example
 module "daily_data_processor" {
   # When used from another repository, this would be:
-  # source = "git::https://github.com/Khan/terraform-scheduled-function-module.git?ref=v1.0.0"
+  # source = "git::https://github.com/Khan/terraform-modules.git//terraform/modules/scheduled-function?ref=v1.0.0"
   source = "../.."
 
   function_name      = "daily-data-processor"
@@ -38,10 +38,10 @@ module "daily_data_processor" {
   description        = "Daily data processing job"
 
   # Job-specific configuration
-  job_cpu    = "2000m"
-  job_memory = "2Gi"
+  job_cpu     = "2000m"
+  job_memory  = "2Gi"
   job_timeout = "7200s" # 2 hours
-  
+
   # Container image (build and push separately)
   job_image = "gcr.io/${var.project_id}/daily-data-processor:latest"
 

--- a/terraform/modules/scheduled-function/examples/simple-job/main.tf
+++ b/terraform/modules/scheduled-function/examples/simple-job/main.tf
@@ -40,7 +40,7 @@ module "daily_data_processor" {
   # Job-specific configuration
   job_cpu    = "2000m"
   job_memory = "2Gi"
-  job_timeout = "7200" # 2 hours
+  job_timeout = 7200 # 2 hours
   
   # Container image (build and push separately)
   job_image = "gcr.io/${var.project_id}/daily-data-processor:latest"

--- a/terraform/modules/scheduled-function/examples/simple-job/variables.tf
+++ b/terraform/modules/scheduled-function/examples/simple-job/variables.tf
@@ -1,0 +1,15 @@
+variable "project_id" {
+  description = "The GCP project ID where resources will be created"
+  type        = string
+}
+
+variable "secrets_project_id" {
+  description = "The GCP project ID where secrets are stored (can be same as project_id)"
+  type        = string
+}
+
+variable "region" {
+  description = "The GCP region where resources will be created"
+  type        = string
+  default     = "us-central1"
+}

--- a/terraform/modules/scheduled-function/main.tf
+++ b/terraform/modules/scheduled-function/main.tf
@@ -67,7 +67,7 @@ resource "google_storage_bucket_object" "function_archive" {
   count = var.execution_type == "function" ? 1 : 0
   
   name   = "${var.function_name}-function-${data.archive_file.function_archive[0].output_sha}.zip"
-  bucket = google_storage_bucket.function_bucket.name
+  bucket = google_storage_bucket.function_bucket[0].name
   source = data.archive_file.function_archive[0].output_path
 }
 

--- a/terraform/modules/scheduled-function/main.tf
+++ b/terraform/modules/scheduled-function/main.tf
@@ -1,5 +1,5 @@
-# Scheduled Cloud Function Module
-# This module creates a complete scheduled Cloud Function setup with all necessary components
+# Scheduled Cloud Function/Job Module
+# This module creates a complete scheduled Cloud Function or Cloud Run Job setup with all necessary components
 
 # Required providers
 terraform {
@@ -17,15 +17,15 @@ terraform {
   }
 }
 
-# Service account for the Cloud Function
+# Service account for the Cloud Function/Job
 resource "google_service_account" "function_sa" {
   project      = var.project_id
   account_id   = "${var.function_name}-sa"
-  display_name = "Service Account for ${var.function_name} function"
-  description  = "Service account used by the ${var.function_name} scheduled Cloud Function"
+  display_name = "Service Account for ${var.function_name} ${var.execution_type}"
+  description  = "Service account used by the ${var.function_name} scheduled ${var.execution_type}"
 }
 
-# Storage bucket for function source code
+# Storage bucket for function/job source code
 resource "google_storage_bucket" "function_bucket" {
   project                     = var.project_id
   name                        = "${var.function_name}-source-${var.project_id}"
@@ -34,33 +34,37 @@ resource "google_storage_bucket" "function_bucket" {
   force_destroy               = true
 }
 
-# Create function source archive
+# Create function/job source archive
 data "archive_file" "function_archive" {
   type        = "zip"
-  output_path = "${path.module}/${var.function_name}-function.zip"
-  source_dir  = abspath(var.source_dir)
+  output_path = "${path.module}/${var.function_name}-${var.execution_type}.zip"
+  source_dir  = var.source_dir
   excludes    = var.excludes
 }
 
-# Upload function archive to storage bucket
+# Upload function/job archive to storage bucket
 # The object name includes the source code hash, ensuring:
 # 1. Cloud Function redeploys when source code changes (new hash = new object name)
 # 2. Terraform automatically deletes old zip files when hash changes (resource replacement)
 # 3. No manual cleanup or lifecycle rules needed - Terraform handles it
 resource "google_storage_bucket_object" "function_archive" {
-  name   = "${var.function_name}-function-${data.archive_file.function_archive.output_sha}.zip"
+  name   = "${var.function_name}-${var.execution_type}-${data.archive_file.function_archive.output_sha}.zip"
   bucket = google_storage_bucket.function_bucket.name
   source = data.archive_file.function_archive.output_path
 }
 
-# PubSub topic for triggering the function
+# PubSub topic for triggering the Cloud Function (only created when execution_type is "function")
 resource "google_pubsub_topic" "function_topic" {
+  count = var.execution_type == "function" ? 1 : 0
+
   project = var.project_id
   name    = "${var.function_name}-topic"
 }
 
-# Cloud Scheduler job
+# Cloud Scheduler job for Cloud Function (only created when execution_type is "function")
 resource "google_cloud_scheduler_job" "function_scheduler" {
+  count = var.execution_type == "function" ? 1 : 0
+
   project     = var.project_id
   name        = "${var.function_name}-scheduler"
   description = var.description
@@ -68,7 +72,7 @@ resource "google_cloud_scheduler_job" "function_scheduler" {
   time_zone   = var.time_zone
 
   pubsub_target {
-    topic_name = google_pubsub_topic.function_topic.id
+    topic_name = google_pubsub_topic.function_topic[0].id
     data       = base64encode("{}")
   }
 }
@@ -85,8 +89,10 @@ resource "google_secret_manager_secret_iam_member" "function_secret_access" {
   member    = "serviceAccount:${google_service_account.function_sa.email}"
 }
 
-# The main Cloud Function
+# The main Cloud Function (only created when execution_type is "function")
 resource "google_cloudfunctions2_function" "function" {
+  count = var.execution_type == "function" ? 1 : 0
+
   project     = var.project_id
   name        = var.function_name
   description = var.description
@@ -135,7 +141,96 @@ resource "google_cloudfunctions2_function" "function" {
   event_trigger {
     trigger_region = var.region
     event_type     = "google.cloud.pubsub.topic.v1.messagePublished"
-    pubsub_topic   = google_pubsub_topic.function_topic.id
+    pubsub_topic   = google_pubsub_topic.function_topic[0].id
     retry_policy   = var.retries_enabled ? "RETRY_POLICY_RETRY" : "RETRY_POLICY_DO_NOT_RETRY"
+  }
+}
+
+# Cloud Run Job (only created when execution_type is "job")
+resource "google_cloud_run_v2_job" "job" {
+  count = var.execution_type == "job" ? 1 : 0
+
+  project  = var.project_id
+  name     = var.function_name
+  location = var.region
+
+  template {
+    template {
+      task_count = var.job_task_count
+      parallelism = var.job_parallelism
+      timeout     = var.job_timeout
+
+      template {
+        containers {
+          image = var.job_image
+          
+          command = var.job_command
+          args    = var.job_args
+
+          resources {
+            limits = {
+              cpu    = var.job_cpu
+              memory = var.job_memory
+            }
+          }
+
+          # Environment variables
+          dynamic "env" {
+            for_each = var.environment_variables
+            content {
+              name  = env.key
+              value = env.value
+            }
+          }
+
+          # Secret environment variables
+          dynamic "env" {
+            for_each = var.secrets
+            content {
+              name = env.value.env_var_name
+              value_source {
+                secret_key_ref {
+                  secret  = env.value.secret_id
+                  version = env.value.version
+                }
+              }
+            }
+          }
+        }
+
+        service_account = google_service_account.function_sa.email
+      }
+    }
+  }
+}
+
+
+
+# Get project number for PubSub service account
+data "google_project" "project" {
+  project_id = var.project_id
+}
+
+# Cloud Scheduler job for Cloud Run Job (only created when execution_type is "job")
+resource "google_cloud_scheduler_job" "job_scheduler" {
+  count = var.execution_type == "job" ? 1 : 0
+
+  project     = var.project_id
+  name        = "${var.function_name}-job-scheduler"
+  description = var.description
+  schedule    = var.schedule
+  time_zone   = var.time_zone
+
+  http_target {
+    http_method = "POST"
+    uri         = "https://${var.region}-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${var.project_id}/jobs/${var.function_name}:run"
+    
+    headers = {
+      "Content-Type" = "application/json"
+    }
+
+    oauth_token {
+      service_account_email = google_service_account.function_sa.email
+    }
   }
 } 

--- a/terraform/modules/scheduled-function/main.tf
+++ b/terraform/modules/scheduled-function/main.tf
@@ -17,18 +17,6 @@ terraform {
   }
 }
 
-# Validation for required variables based on execution type
-locals {
-  # Validate that source_dir and main_file are provided for Cloud Functions
-  validate_function_vars = var.execution_type == "function" ? (
-    var.source_dir == null ? tobool("source_dir is required when execution_type is 'function'") : true
-  ) : true
-  
-  validate_main_file = var.execution_type == "function" ? (
-    var.main_file == null ? tobool("main_file is required when execution_type is 'function'") : true
-  ) : true
-}
-
 # Service account for the Cloud Function/Job
 resource "google_service_account" "function_sa" {
   project      = var.project_id
@@ -40,7 +28,7 @@ resource "google_service_account" "function_sa" {
 # Storage bucket for function source code (only for Cloud Functions)
 resource "google_storage_bucket" "function_bucket" {
   count = var.execution_type == "function" ? 1 : 0
-  
+
   project                     = var.project_id
   name                        = "${var.function_name}-source-${var.project_id}"
   location                    = var.region
@@ -51,10 +39,10 @@ resource "google_storage_bucket" "function_bucket" {
 # Create function source archive (only for Cloud Functions)
 data "archive_file" "function_archive" {
   count = var.execution_type == "function" ? 1 : 0
-  
+
   type        = "zip"
   output_path = "${path.module}/${var.function_name}-function.zip"
-  source_dir  = var.source_dir
+  source_dir  = abspath(var.source_dir)
   excludes    = var.excludes
 }
 
@@ -65,7 +53,7 @@ data "archive_file" "function_archive" {
 # 3. No manual cleanup or lifecycle rules needed - Terraform handles it
 resource "google_storage_bucket_object" "function_archive" {
   count = var.execution_type == "function" ? 1 : 0
-  
+
   name   = "${var.function_name}-function-${data.archive_file.function_archive[0].output_sha}.zip"
   bucket = google_storage_bucket.function_bucket[0].name
   source = data.archive_file.function_archive[0].output_path
@@ -173,13 +161,13 @@ resource "google_cloud_run_v2_job" "job" {
   location = var.region
 
   template {
-    task_count = var.job_task_count
+    task_count  = var.job_task_count
     parallelism = var.job_parallelism
 
     template {
       containers {
         image = var.job_image
-        
+
         command = var.job_command
         args    = var.job_args
 
@@ -222,10 +210,6 @@ resource "google_cloud_run_v2_job" "job" {
 
 
 
-# Get project number for PubSub service account
-data "google_project" "project" {
-  project_id = var.project_id
-}
 
 # Cloud Scheduler job for Cloud Run Job (only created when execution_type is "job")
 resource "google_cloud_scheduler_job" "job_scheduler" {
@@ -239,8 +223,8 @@ resource "google_cloud_scheduler_job" "job_scheduler" {
 
   http_target {
     http_method = "POST"
-    uri         = "https://${var.region}-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${var.project_id}/jobs/${var.function_name}:run"
-    
+    uri         = "https://run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${var.project_id}/jobs/${var.function_name}:run"
+
     headers = {
       "Content-Type" = "application/json"
     }

--- a/terraform/modules/scheduled-function/main.tf
+++ b/terraform/modules/scheduled-function/main.tf
@@ -155,51 +155,49 @@ resource "google_cloud_run_v2_job" "job" {
   location = var.region
 
   template {
+    task_count = var.job_task_count
+    parallelism = var.job_parallelism
+    timeout     = var.job_timeout
+
     template {
-      task_count = var.job_task_count
-      parallelism = var.job_parallelism
-      timeout     = var.job_timeout
+      containers {
+        image = var.job_image
+        
+        command = var.job_command
+        args    = var.job_args
 
-      template {
-        containers {
-          image = var.job_image
-          
-          command = var.job_command
-          args    = var.job_args
-
-          resources {
-            limits = {
-              cpu    = var.job_cpu
-              memory = var.job_memory
-            }
+        resources {
+          limits = {
+            cpu    = var.job_cpu
+            memory = var.job_memory
           }
+        }
 
-          # Environment variables
-          dynamic "env" {
-            for_each = var.environment_variables
-            content {
-              name  = env.key
-              value = env.value
-            }
+        # Environment variables
+        dynamic "env" {
+          for_each = var.environment_variables
+          content {
+            name  = env.key
+            value = env.value
           }
+        }
 
-          # Secret environment variables
-          dynamic "env" {
-            for_each = var.secrets
-            content {
-              name = env.value.env_var_name
-              value_source {
-                secret_key_ref {
-                  secret  = env.value.secret_id
-                  version = env.value.version
-                }
+        # Secret environment variables
+        dynamic "env" {
+          for_each = var.secrets
+          content {
+            name = env.value.env_var_name
+            value_source {
+              secret_key_ref {
+                secret  = env.value.secret_id
+                version = env.value.version
               }
             }
           }
         }
-
-        service_account = google_service_account.function_sa.email
       }
+
+      service_account = google_service_account.function_sa.email
     }
   }
 }

--- a/terraform/modules/scheduled-function/main.tf
+++ b/terraform/modules/scheduled-function/main.tf
@@ -25,8 +25,10 @@ resource "google_service_account" "function_sa" {
   description  = "Service account used by the ${var.function_name} scheduled ${var.execution_type}"
 }
 
-# Storage bucket for function/job source code
+# Storage bucket for function source code (only for Cloud Functions)
 resource "google_storage_bucket" "function_bucket" {
+  count = var.execution_type == "function" ? 1 : 0
+  
   project                     = var.project_id
   name                        = "${var.function_name}-source-${var.project_id}"
   location                    = var.region
@@ -34,23 +36,27 @@ resource "google_storage_bucket" "function_bucket" {
   force_destroy               = true
 }
 
-# Create function/job source archive
+# Create function source archive (only for Cloud Functions)
 data "archive_file" "function_archive" {
+  count = var.execution_type == "function" ? 1 : 0
+  
   type        = "zip"
-  output_path = "${path.module}/${var.function_name}-${var.execution_type}.zip"
+  output_path = "${path.module}/${var.function_name}-function.zip"
   source_dir  = var.source_dir
   excludes    = var.excludes
 }
 
-# Upload function/job archive to storage bucket
+# Upload function archive to storage bucket (only for Cloud Functions)
 # The object name includes the source code hash, ensuring:
 # 1. Cloud Function redeploys when source code changes (new hash = new object name)
 # 2. Terraform automatically deletes old zip files when hash changes (resource replacement)
 # 3. No manual cleanup or lifecycle rules needed - Terraform handles it
 resource "google_storage_bucket_object" "function_archive" {
-  name   = "${var.function_name}-${var.execution_type}-${data.archive_file.function_archive.output_sha}.zip"
+  count = var.execution_type == "function" ? 1 : 0
+  
+  name   = "${var.function_name}-function-${data.archive_file.function_archive[0].output_sha}.zip"
   bucket = google_storage_bucket.function_bucket.name
-  source = data.archive_file.function_archive.output_path
+  source = data.archive_file.function_archive[0].output_path
 }
 
 # PubSub topic for triggering the Cloud Function (only created when execution_type is "function")
@@ -104,8 +110,8 @@ resource "google_cloudfunctions2_function" "function" {
 
     source {
       storage_source {
-        bucket = google_storage_bucket.function_bucket.name
-        object = google_storage_bucket_object.function_archive.name
+        bucket = google_storage_bucket.function_bucket[0].name
+        object = google_storage_bucket_object.function_archive[0].name
       }
     }
 

--- a/terraform/modules/scheduled-function/main.tf
+++ b/terraform/modules/scheduled-function/main.tf
@@ -17,6 +17,18 @@ terraform {
   }
 }
 
+# Validation for required variables based on execution type
+locals {
+  # Validate that source_dir and main_file are provided for Cloud Functions
+  validate_function_vars = var.execution_type == "function" ? (
+    var.source_dir == null ? tobool("source_dir is required when execution_type is 'function'") : true
+  ) : true
+  
+  validate_main_file = var.execution_type == "function" ? (
+    var.main_file == null ? tobool("main_file is required when execution_type is 'function'") : true
+  ) : true
+}
+
 # Service account for the Cloud Function/Job
 resource "google_service_account" "function_sa" {
   project      = var.project_id

--- a/terraform/modules/scheduled-function/main.tf
+++ b/terraform/modules/scheduled-function/main.tf
@@ -157,7 +157,6 @@ resource "google_cloud_run_v2_job" "job" {
   template {
     task_count = var.job_task_count
     parallelism = var.job_parallelism
-    timeout     = var.job_timeout
 
     template {
       containers {
@@ -198,6 +197,7 @@ resource "google_cloud_run_v2_job" "job" {
       }
 
       service_account = google_service_account.function_sa.email
+      timeout         = var.job_timeout
     }
   }
 }

--- a/terraform/modules/scheduled-function/outputs.tf
+++ b/terraform/modules/scheduled-function/outputs.tf
@@ -41,8 +41,8 @@ output "scheduler_job_name" {
 }
 
 output "storage_bucket_name" {
-  description = "Name of the storage bucket containing function/job source"
-  value       = google_storage_bucket.function_bucket.name
+  description = "Name of the storage bucket containing function source (when execution_type is 'function')"
+  value       = var.execution_type == "function" ? google_storage_bucket.function_bucket[0].name : null
 }
 
 output "function_project_id" {

--- a/terraform/modules/scheduled-function/outputs.tf
+++ b/terraform/modules/scheduled-function/outputs.tf
@@ -1,17 +1,22 @@
-# Outputs for the Scheduled Cloud Function module
+# Outputs for the Scheduled Cloud Function/Job module
 
 output "function_name" {
-  description = "Name of the Cloud Function"
-  value       = google_cloudfunctions2_function.function.name
+  description = "Name of the Cloud Function (when execution_type is 'function')"
+  value       = var.execution_type == "function" ? google_cloudfunctions2_function.function[0].name : null
+}
+
+output "job_name" {
+  description = "Name of the Cloud Run Job (when execution_type is 'job')"
+  value       = var.execution_type == "job" ? google_cloud_run_v2_job.job[0].name : null
 }
 
 output "function_url" {
-  description = "URL of the Cloud Function"
-  value       = google_cloudfunctions2_function.function.service_config[0].uri
+  description = "URL of the Cloud Function (when execution_type is 'function')"
+  value       = var.execution_type == "function" ? google_cloudfunctions2_function.function[0].service_config[0].uri : null
 }
 
 output "service_account_email" {
-  description = "Email of the service account used by the function"
+  description = "Email of the service account used by the function/job"
   value       = google_service_account.function_sa.email
 }
 
@@ -21,31 +26,36 @@ output "service_account_id" {
 }
 
 output "pubsub_topic_name" {
-  description = "Name of the PubSub topic that triggers the function"
-  value       = google_pubsub_topic.function_topic.name
+  description = "Name of the PubSub topic that triggers the function (when execution_type is 'function')"
+  value       = var.execution_type == "function" ? google_pubsub_topic.function_topic[0].name : null
 }
 
 output "pubsub_topic_id" {
-  description = "Full resource ID of the PubSub topic"
-  value       = google_pubsub_topic.function_topic.id
+  description = "Full resource ID of the PubSub topic (when execution_type is 'function')"
+  value       = var.execution_type == "function" ? google_pubsub_topic.function_topic[0].id : null
 }
 
 output "scheduler_job_name" {
   description = "Name of the Cloud Scheduler job"
-  value       = google_cloud_scheduler_job.function_scheduler.name
+  value       = var.execution_type == "function" ? google_cloud_scheduler_job.function_scheduler[0].name : google_cloud_scheduler_job.job_scheduler[0].name
 }
 
 output "storage_bucket_name" {
-  description = "Name of the storage bucket containing function source"
+  description = "Name of the storage bucket containing function/job source"
   value       = google_storage_bucket.function_bucket.name
 }
 
 output "function_project_id" {
-  description = "Project ID where the function is deployed"
+  description = "Project ID where the function/job is deployed"
   value       = var.project_id
 }
 
 output "function_region" {
-  description = "Region where the function is deployed"
+  description = "Region where the function/job is deployed"
   value       = var.region
+}
+
+output "execution_type" {
+  description = "The execution type used (function or job)"
+  value       = var.execution_type
 } 

--- a/terraform/modules/scheduled-function/variables.tf
+++ b/terraform/modules/scheduled-function/variables.tf
@@ -159,8 +159,8 @@ variable "job_memory" {
 
 variable "job_timeout" {
   description = "Timeout for the Cloud Run Job in seconds"
-  type        = string
-  default     = "3600"
+  type        = number
+  default     = 3600
 }
 
 variable "job_parallelism" {

--- a/terraform/modules/scheduled-function/variables.tf
+++ b/terraform/modules/scheduled-function/variables.tf
@@ -47,10 +47,6 @@ variable "source_dir" {
   description = "Path to the directory containing the function source code (relative to terraform root, required for Cloud Functions)"
   type        = string
   default     = null
-  validation {
-    condition     = var.execution_type == "function" ? var.source_dir != null : true
-    error_message = "source_dir is required when execution_type is 'function'."
-  }
 }
 
 variable "entry_point" {
@@ -69,10 +65,6 @@ variable "main_file" {
   description = "Name of the main Python file (for GOOGLE_FUNCTION_SOURCE env var, required for Cloud Functions)"
   type        = string
   default     = null
-  validation {
-    condition     = var.execution_type == "function" ? var.main_file != null : true
-    error_message = "main_file is required when execution_type is 'function'."
-  }
 }
 
 # Scheduling configuration

--- a/terraform/modules/scheduled-function/variables.tf
+++ b/terraform/modules/scheduled-function/variables.tf
@@ -44,8 +44,13 @@ variable "secrets_project_id" {
 
 # Source code configuration
 variable "source_dir" {
-  description = "Path to the directory containing the function source code (relative to terraform root)"
+  description = "Path to the directory containing the function source code (relative to terraform root, required for Cloud Functions)"
   type        = string
+  default     = null
+  validation {
+    condition     = var.execution_type == "function" ? var.source_dir != null : true
+    error_message = "source_dir is required when execution_type is 'function'."
+  }
 }
 
 variable "entry_point" {
@@ -61,8 +66,13 @@ variable "runtime" {
 }
 
 variable "main_file" {
-  description = "Name of the main Python file (for GOOGLE_FUNCTION_SOURCE env var)"
+  description = "Name of the main Python file (for GOOGLE_FUNCTION_SOURCE env var, required for Cloud Functions)"
   type        = string
+  default     = null
+  validation {
+    condition     = var.execution_type == "function" ? var.main_file != null : true
+    error_message = "main_file is required when execution_type is 'function'."
+  }
 }
 
 # Scheduling configuration

--- a/terraform/modules/scheduled-function/variables.tf
+++ b/terraform/modules/scheduled-function/variables.tf
@@ -1,11 +1,21 @@
-# Variables for the Scheduled Cloud Function module
-# This module creates a complete scheduled Cloud Function setup with:
-# - Cloud Function (2nd gen)
+# Variables for the Scheduled Cloud Function/Job module
+# This module creates a complete scheduled setup with:
+# - Cloud Function (2nd gen) OR Cloud Run Job
 # - Cloud Scheduler job
 # - PubSub topic for triggering
 # - Service account with appropriate permissions
-# - Storage bucket for function code
+# - Storage bucket for function/job code
 # - Secret Manager IAM bindings
+
+variable "execution_type" {
+  description = "Type of execution: 'function' for Cloud Functions or 'job' for Cloud Run Jobs"
+  type        = string
+  default     = "function"
+  validation {
+    condition     = contains(["function", "job"], var.execution_type)
+    error_message = "Execution type must be either 'function' or 'job'."
+  }
+}
 
 variable "function_name" {
   description = "Name of the Cloud Function and related resources (will be used as prefix)"
@@ -132,5 +142,53 @@ variable "build_environment_variables" {
   description = "Environment variables for the build process"
   type        = map(string)
   default     = {}
+}
+
+# Cloud Run Job specific variables
+variable "job_cpu" {
+  description = "CPU allocation for the Cloud Run Job (e.g., '1000m', '2')"
+  type        = string
+  default     = "1000m"
+}
+
+variable "job_memory" {
+  description = "Memory allocation for the Cloud Run Job (e.g., '512Mi', '2Gi')"
+  type        = string
+  default     = "512Mi"
+}
+
+variable "job_timeout" {
+  description = "Timeout for the Cloud Run Job in seconds"
+  type        = string
+  default     = "3600"
+}
+
+variable "job_parallelism" {
+  description = "Number of parallel executions for the Cloud Run Job"
+  type        = number
+  default     = 1
+}
+
+variable "job_task_count" {
+  description = "Number of tasks to run for the Cloud Run Job"
+  type        = number
+  default     = 1
+}
+
+variable "job_command" {
+  description = "Command to run in the Cloud Run Job container"
+  type        = list(string)
+  default     = ["python", "main.py"]
+}
+
+variable "job_args" {
+  description = "Arguments to pass to the command in the Cloud Run Job"
+  type        = list(string)
+  default     = []
+}
+
+variable "job_image" {
+  description = "Container image URL for the Cloud Run Job (e.g., 'gcr.io/project-id/job-name:latest')"
+  type        = string
 }
 

--- a/terraform/modules/scheduled-function/variables.tf
+++ b/terraform/modules/scheduled-function/variables.tf
@@ -158,9 +158,9 @@ variable "job_memory" {
 }
 
 variable "job_timeout" {
-  description = "Timeout for the Cloud Run Job in seconds"
-  type        = number
-  default     = 3600
+  description = "Timeout for the Cloud Run Job (e.g., '3600s', '1h', '2h30m')"
+  type        = string
+  default     = "3600s"
 }
 
 variable "job_parallelism" {


### PR DESCRIPTION
## Summary:
This PR extends the scheduled-function module to support Cloud Run Jobs in addition to Cloud Functions, addressing specific migration needs from our legacy infrastructure. The module now provides a unified interface for creating scheduled workloads in Google Cloud Platform.

**Motivation:**
We're migrating cronjobs from our legacy infrastructure (toby) that have requirements beyond what Cloud Functions can support:
- **Custom environments**: Jobs using alertlib, CLI utilities (gcloud), or SMTP servers
- **Filesystem access**: Jobs requiring significant local storage or file operations
- **Complex dependencies**: Jobs needing custom runtime environments or system packages

Cloud Run Jobs provide the flexibility needed for these workloads while maintaining the scheduled execution model we already have with Cloud Functions.

**Key additions:**
- New `execution_type` variable to choose between "function" and "job"
- Cloud Run Job-specific variables (CPU, memory, timeout, parallelism, task count, command, args, container image)
- Conditional resource creation based on execution type
- Separate Cloud Scheduler job for Cloud Run Jobs using HTTP targets
- Updated outputs to handle both execution types
- Comprehensive example with sample code and Dockerfile
- Enhanced documentation with usage examples and comparison table

The implementation maintains full backward compatibility - existing Cloud Function configurations continue to work unchanged.

## Test plan:
- Verified backward compatibility with existing Cloud Function examples
- Created new Cloud Run Job example with complete configuration
- Updated documentation with comprehensive examples and usage guidelines
- Tested conditional resource creation logic
- Validated output handling for both execution types