### PR TITLE
Add Cloud Run and Cloud Build support to GitHub CI Bootstrap module

### DIFF
--- a/terraform/modules/github-ci-bootstrap/README.md
+++ b/terraform/modules/github-ci-bootstrap/README.md
@@ -45,7 +45,7 @@ module "culture_cron_terraform_ci" {
   # Target projects where this Terraform configuration deploys resources via CI
   target_projects = {
     "khan-academy" = {
-      required_services = ["cloudfunctions", "storage", "pubsub", "scheduler"]
+      required_services = ["cloudfunctions", "storage", "pubsub", "scheduler", "run", "cloudbuild"]
     }
   }
   
@@ -93,6 +93,8 @@ These services correspond to GCP resources that your Terraform configuration can
 - `storage` - Enables creating and managing Cloud Storage buckets via Terraform  
 - `pubsub` - Enables creating and managing Pub/Sub topics and subscriptions via Terraform
 - `scheduler` - Enables creating and managing Cloud Scheduler jobs via Terraform
+- `run` - Enables deploying and managing Cloud Run services and jobs via Terraform
+- `cloudbuild` - Enables creating and managing Cloud Build triggers and configurations via Terraform
 
 ### Terraform State Bucket Default
 
@@ -285,5 +287,25 @@ module "static_site_prod_ci" {
   }
   
   # Terraform state bucket defaults to: terraform-khan-static-site-static-site-prod
+}
+```
+
+### Terraform Configuration with Cloud Run and Cloud Build
+```hcl
+# CI for webapp Terraform configuration that manages Cloud Run services and Cloud Build
+module "webapp_prod_ci" {
+  source = "git::https://github.com/Khan/terraform-modules.git//terraform/modules/github-ci-bootstrap?ref=v1.0.0"
+
+  service_name      = "webapp-prod"
+  github_repository = "Khan/webapp"
+  
+  # This Terraform config manages Cloud Run services, jobs, and Cloud Build
+  target_projects = {
+    "khan-academy" = {
+      required_services = ["run", "cloudbuild", "storage"]
+    }
+  }
+  
+  # Terraform state bucket defaults to: terraform-khan-webapp-webapp-prod
 }
 ```

--- a/terraform/modules/github-ci-bootstrap/examples/bootstrap-with-module/README.md
+++ b/terraform/modules/github-ci-bootstrap/examples/bootstrap-with-module/README.md
@@ -8,7 +8,7 @@ This configuration uses the reusable `github-ci-bootstrap` module to create:
 
 - Service account for running Terraform operations in GitHub Actions (in khan-internal-services project)
 - Workload Identity Federation using shared pool for keyless authentication
-- IAM permissions for deploying Cloud Functions, Storage, Pub/Sub, and Scheduler resources via Terraform
+- IAM permissions for deploying Cloud Functions, Storage, Pub/Sub, Scheduler, Cloud Run (services and jobs), and Cloud Build resources via Terraform
 - Access to secrets in Google Secret Manager that the Terraform configuration needs
 - Permissions for Terraform state bucket management
 
@@ -73,7 +73,7 @@ The module is configured for the Culture Cron production Terraform configuration
 
 - **Terraform Configuration**: `culture-cron-prod` (production environment managed in CI)
 - **Repository**: `Khan/culture-cron` (GitHub repository containing Terraform code)
-- **Target Project**: `khan-internal-services` with Cloud Functions, Storage, Pub/Sub, Scheduler services
+- **Target Project**: `khan-internal-services` with Cloud Functions, Storage, Pub/Sub, Scheduler, Cloud Run (services and jobs), and Cloud Build services
 - **State Bucket**: `terraform-khan-culture-cron-culture-cron-prod` (automatically computed from repository and service)
 - **Secrets**: `khan-academy` (Slack token storage needed by the Terraform configuration)
 

--- a/terraform/modules/github-ci-bootstrap/examples/bootstrap-with-module/main.tf
+++ b/terraform/modules/github-ci-bootstrap/examples/bootstrap-with-module/main.tf
@@ -34,7 +34,7 @@ module "culture_cron_bootstrap" {
   # Target projects - culture-cron deploys to khan-internal-services
   target_projects = {
     (var.project_id) = {
-      required_services = ["cloudfunctions", "storage", "pubsub", "scheduler"]
+      required_services = ["cloudfunctions", "storage", "pubsub", "scheduler", "run", "cloudbuild"]
     }
   }
 

--- a/terraform/modules/github-ci-bootstrap/main.tf
+++ b/terraform/modules/github-ci-bootstrap/main.tf
@@ -19,6 +19,8 @@ locals {
     storage        = "roles/storage.admin"
     pubsub         = "roles/pubsub.admin"
     scheduler      = "roles/cloudscheduler.admin"
+    run            = "roles/run.admin"
+    cloudbuild     = "roles/cloudbuild.builds.builder"
   }
 
   # Parse GitHub repository into org and repo name

--- a/terraform/modules/github-ci-bootstrap/variables.tf
+++ b/terraform/modules/github-ci-bootstrap/variables.tf
@@ -31,11 +31,13 @@ variable "target_projects" {
           "cloudfunctions",
           "storage",
           "pubsub",
-          "scheduler"
+          "scheduler",
+          "run",
+          "cloudbuild"
         ], service)
       ]
     ]))
-    error_message = "Required services must be one of: cloudfunctions, storage, pubsub, scheduler."
+    error_message = "Required services must be one of: cloudfunctions, storage, pubsub, scheduler, run, cloudbuild."
   }
 }
 


### PR DESCRIPTION
## Summary:
This PR adds support for Cloud Run (services and jobs) and Cloud Build to the GitHub CI Bootstrap module. The changes include:

- Added `run` service support with `roles/run.admin` role for Cloud Run services and jobs
- Added `cloudbuild` service support with `roles/cloudbuild.builds.builder` role for Cloud Build
- Updated service validation to include the new services
- Updated documentation and examples to reflect the new capabilities
- Added a new example showing Cloud Run and Cloud Build usage

The `run` service covers both Cloud Run services and Cloud Run jobs since they use the same IAM role. This simplifies the configuration while maintaining full functionality.

## Test plan:
- Verify Terraform validation passes for the updated module
- Test that the new services can be specified in target_projects configuration
- Confirm that the appropriate IAM roles are assigned when the new services are enabled
- Validate that existing functionality remains unchanged