### PR TITLE
[🔥AUDIT🔥] Make job_name not required for scheduled functions

### DIFF
--- a/terraform/modules/scheduled-job/main.tf
+++ b/terraform/modules/scheduled-job/main.tf
@@ -160,6 +160,13 @@ resource "google_cloud_run_v2_job" "job" {
   name     = var.job_name
   location = var.region
 
+  lifecycle {
+    precondition {
+      condition     = var.job_image != null
+      error_message = "job_image is required when execution_type is 'job'."
+    }
+  }
+
   template {
     task_count  = var.job_task_count
     parallelism = var.job_parallelism

--- a/terraform/modules/scheduled-job/variables.tf
+++ b/terraform/modules/scheduled-job/variables.tf
@@ -192,5 +192,9 @@ variable "job_args" {
 variable "job_image" {
   description = "Container image URL for the Cloud Run Job (e.g., 'gcr.io/project-id/job-name:latest')"
   type        = string
+  default     = null
+  validation {
+    condition = var.execution_type != "job" || var.job_image != null
+    error_message = "job_image is required when execution_type is 'job'."
+  }
 }
-

--- a/terraform/modules/scheduled-job/variables.tf
+++ b/terraform/modules/scheduled-job/variables.tf
@@ -193,8 +193,4 @@ variable "job_image" {
   description = "Container image URL for the Cloud Run Job (e.g., 'gcr.io/project-id/job-name:latest')"
   type        = string
   default     = null
-  validation {
-    condition = var.execution_type != "job" || var.job_image != null
-    error_message = "job_image is required when execution_type is 'job'."
-  }
 }


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
This should be required for scheduled functions and shouldn't be required for cloud run jobs.

Issue: INFRA-XXXX

## Test plan:
update culture-cron to pull this in