### PR TITLE
[🔥AUDIT🔥] Fix secret access timing and deletion protection issues in scheduled-job module

### DIFF
--- a/terraform/modules/scheduled-job/main.tf
+++ b/terraform/modules/scheduled-job/main.tf
@@ -104,6 +104,9 @@ resource "google_cloudfunctions2_function" "function" {
   description = var.description
   location    = var.region
 
+  # Ensure IAM bindings are created before the function
+  depends_on = [google_secret_manager_secret_iam_member.function_secret_access]
+
   build_config {
     runtime     = var.runtime
     entry_point = var.entry_point
@@ -159,6 +162,12 @@ resource "google_cloud_run_v2_job" "job" {
   project  = var.project_id
   name     = var.job_name
   location = var.region
+
+  # Allow Terraform to manage the job lifecycle
+  deletion_protection = false
+
+  # Ensure IAM bindings are created before the job
+  depends_on = [google_secret_manager_secret_iam_member.function_secret_access]
 
   lifecycle {
     precondition {

--- a/terraform/modules/scheduled-job/main.tf
+++ b/terraform/modules/scheduled-job/main.tf
@@ -95,6 +95,11 @@ resource "google_secret_manager_secret_iam_member" "function_secret_access" {
   member    = "serviceAccount:${google_service_account.function_sa.email}"
 }
 
+# Local value that depends on all IAM bindings being created
+locals {
+  iam_bindings_ready = length(var.secrets) > 0 ? google_secret_manager_secret_iam_member.function_secret_access : {}
+}
+
 # The main Cloud Function (only created when execution_type is "function")
 resource "google_cloudfunctions2_function" "function" {
   count = var.execution_type == "function" ? 1 : 0
@@ -105,7 +110,7 @@ resource "google_cloudfunctions2_function" "function" {
   location    = var.region
 
   # Ensure IAM bindings are created before the function
-  depends_on = [google_secret_manager_secret_iam_member.function_secret_access]
+  depends_on = [local.iam_bindings_ready, google_service_account.function_sa]
 
   build_config {
     runtime     = var.runtime
@@ -167,7 +172,7 @@ resource "google_cloud_run_v2_job" "job" {
   deletion_protection = false
 
   # Ensure IAM bindings are created before the job
-  depends_on = [google_secret_manager_secret_iam_member.function_secret_access]
+  depends_on = [local.iam_bindings_ready, google_service_account.function_sa]
 
   lifecycle {
     precondition {

--- a/terraform/modules/scheduled-job/main.tf
+++ b/terraform/modules/scheduled-job/main.tf
@@ -95,11 +95,6 @@ resource "google_secret_manager_secret_iam_member" "function_secret_access" {
   member    = "serviceAccount:${google_service_account.function_sa.email}"
 }
 
-# Local value that depends on all IAM bindings being created
-locals {
-  iam_bindings_ready = length(var.secrets) > 0 ? google_secret_manager_secret_iam_member.function_secret_access : {}
-}
-
 # The main Cloud Function (only created when execution_type is "function")
 resource "google_cloudfunctions2_function" "function" {
   count = var.execution_type == "function" ? 1 : 0
@@ -109,8 +104,8 @@ resource "google_cloudfunctions2_function" "function" {
   description = var.description
   location    = var.region
 
-  # Ensure IAM bindings are created before the function
-  depends_on = [local.iam_bindings_ready, google_service_account.function_sa]
+  # Ensure service account is created before the function
+  depends_on = [google_service_account.function_sa]
 
   build_config {
     runtime     = var.runtime
@@ -171,8 +166,8 @@ resource "google_cloud_run_v2_job" "job" {
   # Allow Terraform to manage the job lifecycle
   deletion_protection = false
 
-  # Ensure IAM bindings are created before the job
-  depends_on = [local.iam_bindings_ready, google_service_account.function_sa]
+  # Ensure service account is created before the job
+  depends_on = [google_service_account.function_sa]
 
   lifecycle {
     precondition {
@@ -215,7 +210,7 @@ resource "google_cloud_run_v2_job" "job" {
             name = env.value.env_var_name
             value_source {
               secret_key_ref {
-                secret  = env.value.secret_id
+                secret  = "projects/${var.secrets_project_id}/secrets/${env.value.secret_id}"
                 version = env.value.version
               }
             }


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
Fixed a critical issue in the scheduled-job module where Cloud Run Jobs could not access secrets from different projects.

**Root Cause**: Cloud Run Jobs were referencing secrets without specifying the project ID, causing them to look for secrets in the same project where the job was running instead of the project where the secret actually exists.

**Solution**: Updated the secret reference in Cloud Run Jobs to use the full project path format: `projects/{project_id}/secrets/{secret_id}` for cross-project secret access.

**Additional Fix**: Added `deletion_protection = false` to Cloud Run Jobs to allow Terraform to properly manage the job lifecycle.

## Changes:
- **Cloud Run Job secret reference**: Now uses `projects/${var.secrets_project_id}/secrets/${env.value.secret_id}` format for cross-project secret access
- **Cloud Run Job lifecycle**: Added `deletion_protection = false` to allow Terraform to destroy and recreate jobs when needed
- **Dependencies**: Simplified to just depend on service account creation for proper resource ordering

## Technical Details:
The issue occurred because:
1. Secrets were stored in `khan-academy` project
2. Cloud Run Jobs were created in `khan-internal-services` project  
3. Jobs were trying to access secrets using just the secret name, which defaulted to the same project
4. This caused "Permission denied on secret" errors even though IAM bindings were correct

The fix ensures Cloud Run Jobs explicitly reference secrets with their full project path, resolving the cross-project access issue.

Issue: None

## Test plan:
1. Deploy a Cloud Run Job with secrets from a different project using the scheduled-job module
2. Verify the job can access cross-project secrets without permission errors
3. Test both function and job execution types
4. Confirm Terraform can destroy and recreate jobs when needed
5. Verify no regression in existing functionality for same-project secrets
