### PR TITLE
Fix Docker image rebuild detection in cloud-build-docker module

### DIFF
--- a/terraform/modules/cloud-build-docker/cloudbuild.yml
+++ b/terraform/modules/cloud-build-docker/cloudbuild.yml
@@ -1,5 +1,5 @@
 # Cloud Build configuration with branch-based caching.
-# Enables caching by pulling the previous image with a given "cache tag", if it exists, and reusing its layers.
+# Enables caching by pulling the previous image with a given "cache tag", if it exists, which allows docker to reuse layers.
 steps:
   - name: 'gcr.io/cloud-builders/docker'
     id: Pull previous image
@@ -16,13 +16,8 @@ steps:
     args:
       - -c
       - |
-        if docker image inspect "$_IMAGE_NAME:$_CACHE_TAG" > /dev/null 2>&1; then
-          echo "Using cache from $_IMAGE_NAME:$_CACHE_TAG"
-          docker build --tag="$_IMAGE_TAG" --cache-from="$_IMAGE_NAME:$_CACHE_TAG" --build-arg BASE_IMAGE="$_BASE_DIGEST" .
-        else
-          echo "No cache found for $_IMAGE_NAME:$_CACHE_TAG, building without --cache-from"
-          docker build --tag="$_IMAGE_TAG" --build-arg BASE_IMAGE="$_BASE_DIGEST" .
-        fi
+        echo "Building image"
+        docker build --tag="$_IMAGE_TAG" --build-arg BASE_IMAGE="$_BASE_DIGEST" .
 
   - name: 'gcr.io/cloud-builders/docker'
     id: Tag cache

--- a/terraform/modules/cloud-build-docker/main.tf
+++ b/terraform/modules/cloud-build-docker/main.tf
@@ -18,12 +18,11 @@ terraform {
 }
 
 
-# Null resource to track context changes and trigger rebuilds
-resource "null_resource" "context_hash" {
-  triggers = {
-    dockerfile_hash = filebase64sha256("${var.context_path}/${var.dockerfile_path}")
-    context_files_hash = sha256(join(",", [for f in fileset(var.context_path, "**") : filebase64sha256("${var.context_path}/${f}")]))
-  }
+# Local values for tracking context changes
+locals {
+  dockerfile_hash = filebase64sha256("${var.context_path}/${var.dockerfile_path}")
+  context_files_hash = sha256(join(",", [for f in fileset(var.context_path, "**") : filebase64sha256("${var.context_path}/${f}")]))
+  context_hash = "${local.dockerfile_hash}-${local.context_files_hash}"
 }
 
 # External data source to build images and return their digests
@@ -45,7 +44,7 @@ data "external" "image_build" {
     var.dockerfile_path,
     var.image_tag_suffix,
     var.project_id,
-    null_resource.context_hash
+    local.context_hash
   ]
 }
 

--- a/terraform/modules/cloud-build-docker/main.tf
+++ b/terraform/modules/cloud-build-docker/main.tf
@@ -20,9 +20,9 @@ terraform {
 
 # Local values for tracking context changes
 locals {
-  dockerfile_hash = filebase64sha256("${var.context_path}/${var.dockerfile_path}")
+  dockerfile_hash    = filebase64sha256("${var.context_path}/${var.dockerfile_path}")
   context_files_hash = sha256(join(",", [for f in fileset(var.context_path, "**") : filebase64sha256("${var.context_path}/${f}")]))
-  context_hash = "${local.dockerfile_hash}-${local.context_files_hash}"
+  context_hash       = "${local.dockerfile_hash}-${local.context_files_hash}"
 }
 
 # External data source to build images and return their digests

--- a/terraform/modules/cloud-build-docker/main.tf
+++ b/terraform/modules/cloud-build-docker/main.tf
@@ -18,11 +18,9 @@ terraform {
 }
 
 
-# Local values for tracking context changes
-locals {
-  dockerfile_hash    = filebase64sha256("${var.context_path}/${var.dockerfile_path}")
-  context_files_hash = sha256(join(",", [for f in fileset(var.context_path, "**") : filebase64sha256("${var.context_path}/${f}")]))
-  context_hash       = "${local.dockerfile_hash}-${local.context_files_hash}"
+# Data source to track context changes
+data "external" "context_hash" {
+  program = ["bash", "-c", "cd ${var.context_path} && find . -type f -exec sha256sum {} \\; | sort | sha256sum | awk '{print \"{\\\"hash\\\": \\\"\" $1 \"\\\"}\"}'"]
 }
 
 # External data source to build images and return their digests
@@ -44,7 +42,7 @@ data "external" "image_build" {
     var.dockerfile_path,
     var.image_tag_suffix,
     var.project_id,
-    local.context_hash
+    data.external.context_hash
   ]
 }
 

--- a/terraform/modules/cloud-build-docker/main.tf
+++ b/terraform/modules/cloud-build-docker/main.tf
@@ -22,7 +22,7 @@ terraform {
 resource "null_resource" "context_hash" {
   triggers = {
     dockerfile_hash = filebase64sha256("${var.context_path}/${var.dockerfile_path}")
-    context_files = join(",", [for f in fileset(var.context_path, "**") : filebase64sha256("${var.context_path}/${f}")])
+    context_files_hash = sha256(join(",", [for f in fileset(var.context_path, "**") : filebase64sha256("${var.context_path}/${f}")]))
   }
 }
 

--- a/terraform/modules/cloud-build-docker/main.tf
+++ b/terraform/modules/cloud-build-docker/main.tf
@@ -17,12 +17,6 @@ terraform {
   }
 }
 
-
-# Data source to track context changes
-data "external" "context_hash" {
-  program = ["bash", "-c", "cd ${var.context_path} && find . -type f -exec sha256sum {} \\; | sort | sha256sum | awk '{print \"{\\\"hash\\\": \\\"\" $1 \"\\\"}\"}'"]
-}
-
 # External data source to build images and return their digests
 data "external" "image_build" {
   program = ["${path.module}/build_image.py"]
@@ -36,13 +30,12 @@ data "external" "image_build" {
     base_digest      = var.base_digest
   }
 
-  # Trigger rebuild when any of these change, including Dockerfile and context files
+  # Trigger rebuild when any of these change
   depends_on = [
     var.context_path,
     var.dockerfile_path,
     var.image_tag_suffix,
-    var.project_id,
-    data.external.context_hash
+    var.project_id
   ]
 }
 

--- a/terraform/modules/cloud-build-docker/main.tf
+++ b/terraform/modules/cloud-build-docker/main.tf
@@ -17,6 +17,15 @@ terraform {
   }
 }
 
+
+# Null resource to track context changes and trigger rebuilds
+resource "null_resource" "context_hash" {
+  triggers = {
+    dockerfile_hash = filebase64sha256("${var.context_path}/${var.dockerfile_path}")
+    context_files = join(",", [for f in fileset(var.context_path, "**") : filebase64sha256("${var.context_path}/${f}")])
+  }
+}
+
 # External data source to build images and return their digests
 data "external" "image_build" {
   program = ["${path.module}/build_image.py"]
@@ -30,12 +39,13 @@ data "external" "image_build" {
     base_digest      = var.base_digest
   }
 
-  # Trigger rebuild when any of these change
+  # Trigger rebuild when any of these change, including Dockerfile and context files
   depends_on = [
     var.context_path,
     var.dockerfile_path,
     var.image_tag_suffix,
-    var.project_id
+    var.project_id,
+    null_resource.context_hash
   ]
 }
 


### PR DESCRIPTION
## Summary:
Problem: The cloud-build-docker module wasn't detecting changes to source files in the context directory, causing Docker images to not rebuild when the Dockerfile or source code changed.
Solution: Added a null_resource with triggers that tracks changes to all files in the context directory using Terraform's built-in fileset and filebase64sha256 functions. This ensures the image rebuilds whenever any relevant files change.
Changes:
Added null_resource.context_hash with triggers for Dockerfile and all context files
Updated depends_on to include the context hash resource
Removed hardcoded file tracking in favor of comprehensive directory monitoring
Impact: Docker images will now automatically rebuild when source code changes, even when using the same image tag suffix like latest.

Issue: INFRA-XXXX

## Test plan:
tested in https://github.com/Khan/internal-webserver/pull/80