### PR TITLE
[🔥AUDIT🔥] Add roles/secretmanager.admin to CI bootstrap service account

### DIFF
--- a/terraform/modules/github-ci-bootstrap/main.tf
+++ b/terraform/modules/github-ci-bootstrap/main.tf
@@ -120,20 +120,12 @@ resource "google_storage_bucket_iam_member" "ci_storage_legacy_bucket_owner" {
 
 # === SECRET MANAGER ===
 
-# Allow reading secret metadata (needed for data.google_secret_manager_secret_version)
-resource "google_project_iam_member" "ci_secretmanager_viewer" {
-  count   = length(var.secret_ids) > 0 ? 1 : 0
-  project = var.secrets_project_id
-  role    = "roles/secretmanager.viewer"
-  member  = "serviceAccount:${google_service_account.github_ci.email}"
-}
-
-# Dynamic secret access based on provided secret IDs
-resource "google_secret_manager_secret_iam_member" "ci_secret_access" {
+# Dynamic secret admin access based on provided secret IDs
+resource "google_secret_manager_secret_iam_member" "ci_secret_admin" {
   for_each  = toset(var.secret_ids)
   project   = var.secrets_project_id
   secret_id = each.value
-  role      = "roles/secretmanager.secretAccessor"
+  role      = "roles/secretmanager.admin"
   member    = "serviceAccount:${google_service_account.github_ci.email}"
 }
 


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
I must've missed this because of all of the testing on local I've done, but when trying to run an apply in [internal-webserver](https://github.com/Khan/internal-webserver/actions/runs/17247176317/job/48939744711), it fails due to not being able to set iam roles on secrets. This should solve that.

Issue: INFRA-XXXX

## Test plan:
Run this on a branch in internal-webserver, then verify an apply works.