### PR TITLE
Add Dual Service Account Support for Enhanced Security

### DIFF
--- a/terraform/modules/github-ci-bootstrap/README.md
+++ b/terraform/modules/github-ci-bootstrap/README.md
@@ -131,6 +131,7 @@ The module always creates two service accounts with different permission levels:
 - **Access**: Can read resources and run builds, but cannot modify infrastructure
 - **Branch Restriction**: Works on any branch in the repository (safe to use anywhere)
 - **Use Case**: PR validation, testing, and plan operations
+- **Notw**: The one read/write role this service account has is for cloud build. As long as docker images are being referenced with image digests, this cannot affect prod. If tags are used, PR branches can push images to those tags and affect prod deplpoyments.
 
 #### Permission Differences
 

--- a/terraform/modules/github-ci-bootstrap/README.md
+++ b/terraform/modules/github-ci-bootstrap/README.md
@@ -15,6 +15,7 @@ Each module invocation creates a dedicated service account for a complete Terraf
 
 - **Shared Infrastructure**: Uses a single Workload Identity Pool in khan-internal-services for all GitHub Terraform CI
 - **Dedicated Service Accounts**: Creates unique service accounts for each Terraform configuration managed in CI
+- **Dual Service Account Support**: Always creates separate service accounts for write-enabled branches (full access) and read-only access (available to any branch)
 - **Workload Identity Federation**: Uses modern, keyless authentication for GitHub Actions
 - **Cross-Project Support**: Service accounts can deploy Terraform resources across multiple GCP projects
 - **Least Privilege**: Only grants permissions for specified GCP services in target projects
@@ -22,6 +23,7 @@ Each module invocation creates a dedicated service account for a complete Terraf
 - **Secret Management**: Optional access to Google Secret Manager secrets needed by Terraform
 - **Configurable Services**: Enable only the GCP services your Terraform configuration manages
 - **Repository Scoped**: Restricts access to a specific GitHub repository containing Terraform code
+- **Branch-Based Access Control**: Different permission levels based on GitHub branch patterns
 
 ## Architecture
 
@@ -41,6 +43,9 @@ module "culture_cron_terraform_ci" {
   # Terraform configuration managed in CI
   service_name      = "culture-cron-prod"        # YOU choose this name: project + environment
   github_repository = "Khan/culture-cron"        # GitHub repo containing the Terraform code
+  
+  # Configure which branches can use the write-enabled service account (defaults to main and master)
+  write_branch_patterns = ["main", "master"]
   
   # Target projects where this Terraform configuration deploys resources via CI
   target_projects = {
@@ -66,6 +71,7 @@ module "culture_cron_terraform_ci" {
 | `service_name` | User-defined unique identifier for this Terraform configuration and environment (e.g., 'culture-cron-prod', 'webapp-staging') | `string` | n/a | yes |
 | `github_repository` | GitHub repository containing the Terraform configuration in format 'org/repo' | `string` | n/a | yes |
 | `target_projects` | Map of GCP projects where this Terraform configuration will deploy resources. Keys are project IDs. | `map(object)` | `{}` | no |
+| `write_branch_patterns` | List of branch patterns that are allowed to use the read/write service account (defaults to main and master) | `list(string)` | `["main", "master"]` | no |
 | `terraform_state_bucket` | GCS bucket name for storing Terraform state for this configuration | `string` | `terraform-{org}-{repo}-{service}` | no |
 | `secrets_project_id` | Project ID where secrets needed by the Terraform configuration are stored | `string` | `"khan-academy"` | no |
 | `secret_ids` | List of secret IDs that the Terraform configuration needs access to | `list(string)` | `[]` | no |
@@ -107,6 +113,47 @@ If `terraform_state_bucket` is not specified, the module automatically generates
 - **Example**: `Khan/Mobile_App` + `mobile_app_prod` → `terraform-khan-mobile-app-mobile-app-prod`
 
 This ensures each Terraform setup gets its own isolated state bucket while maintaining consistent, predictable naming that complies with GCS bucket naming requirements.
+
+### Dual Service Account Configuration
+
+The module always creates two service accounts with different permission levels:
+
+#### Write-Enabled Branch Service Account (Full Access)
+- **Service Account Name**: `{service_name}-ci`
+- **Permissions**: Full admin permissions for all specified services
+- **Access**: Can create, modify, and delete resources
+- **Branch Restriction**: Only works on branches specified in `write_branch_patterns` (defaults to `main` and `master`)
+- **Use Case**: Production deployments and infrastructure changes
+
+#### Read-Only Service Account (Read-Only + Cloud Build)
+- **Service Account Name**: `{service_name}-ci-pr`
+- **Permissions**: Read-only permissions for most services, full access to Cloud Build
+- **Access**: Can read resources and run builds, but cannot modify infrastructure
+- **Branch Restriction**: Works on any branch in the repository (safe to use anywhere)
+- **Use Case**: PR validation, testing, and plan operations
+
+#### Permission Differences
+
+| Service | Write-Enabled Branches | Read-Only Service Account |
+|---------|----------------------|---------------------------|
+| Cloud Functions | `roles/cloudfunctions.admin` | `roles/cloudfunctions.viewer` |
+| Storage | `roles/storage.admin` | `roles/storage.objectViewer` |
+| Pub/Sub | `roles/pubsub.admin` | `roles/pubsub.viewer` |
+| Scheduler | `roles/cloudscheduler.admin` | `roles/cloudscheduler.viewer` |
+| Cloud Run | `roles/run.admin` | `roles/run.viewer` |
+| Cloud Build | `roles/cloudbuild.builds.builder` | `roles/cloudbuild.builds.builder` |
+| Secret Manager | `roles/secretmanager.admin` | `roles/secretmanager.secretAccessor` |
+| Terraform State | `roles/storage.objectAdmin` | `roles/storage.objectViewer` |
+
+#### Branch Pattern Configuration
+
+The `write_branch_patterns` variable accepts exact branch names:
+- `main` - Matches the main branch
+- `master` - Matches the master branch
+- `production` - Matches a production branch
+- `staging` - Matches a staging branch
+
+**Note**: The read-only service account can be used by any branch in the repository since it's inherently safe (cannot make infrastructure changes). Only branches specified in `write_branch_patterns` can use the write-enabled service account for deployments.
 
 ### Service Name Guidelines
 
@@ -160,15 +207,18 @@ Each `service_name` gets its own isolated:
 
 | Name | Description |
 |------|-------------|
-| `service_account_email` | Email of the created service account |
-| `workload_identity_provider` | Full resource name of the Workload Identity provider |
+| `service_account_email` | Email of the created service account (write-enabled branches) |
+| `service_account_email_pr` | Email of the created service account (read-only, available to any branch) |
+| `workload_identity_provider` | Full resource name of the Workload Identity provider (write-enabled branches) |
+| `workload_identity_provider_pr` | Full resource name of the Workload Identity provider (read-only, available to any branch) |
 | `terraform_state_bucket` | The GCS bucket name used for Terraform state (computed or provided) |
 | `service_name` | The unique identifier for this Terraform configuration and environment |
 | `target_projects` | Map of target projects configured |
+| `write_branch_patterns` | List of branch patterns that are allowed to use the read/write service account |
 
 ## GitHub Actions Configuration
 
-After applying this module, configure your GitHub Actions workflow to manage Terraform in CI:
+After applying this module, configure your GitHub Actions workflow to manage Terraform in CI. The module creates two service accounts, so you need to conditionally use different service accounts based on the branch:
 
 ```yaml
 permissions:
@@ -181,14 +231,34 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       
-      - name: Authenticate to Google Cloud
+      - name: Authenticate to Google Cloud (Write-Enabled Branches)
+        if: contains(fromJSON('["refs/heads/main", "refs/heads/master"]'), github.ref)
         uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: ${{ outputs.workload_identity_provider }}
           service_account: ${{ outputs.service_account_email }}
           
+      - name: Authenticate to Google Cloud (Read-Only - Any Branch)
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ outputs.workload_identity_provider_pr }}
+          service_account: ${{ outputs.service_account_email_pr }}
+          
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
+```
+
+### Conditional Terraform Operations
+
+With dual service accounts, you can also conditionally run different Terraform operations:
+
+```yaml
+      - name: Terraform Plan (All Branches)
+        run: terraform plan
+        
+      - name: Terraform Apply (Write-Enabled Branches Only)
+        if: contains(fromJSON('["refs/heads/main", "refs/heads/master"]'), github.ref)
+        run: terraform apply -auto-approve
 ```
 
 ## Security Features
@@ -307,5 +377,33 @@ module "webapp_prod_ci" {
   }
   
   # Terraform state bucket defaults to: terraform-khan-webapp-webapp-prod
+}
+```
+
+### Terraform Configuration with Dual Service Accounts
+```hcl
+# CI for API production Terraform configuration with separate service accounts for main and PR branches
+module "api_prod_ci" {
+  source = "git::https://github.com/Khan/terraform-modules.git//terraform/modules/github-ci-bootstrap?ref=v1.0.0"
+
+  service_name      = "api-prod"
+  github_repository = "Khan/api"
+  
+  # Configure which branches can use the write-enabled service account
+  write_branch_patterns = ["main", "master"]
+  
+  target_projects = {
+    "khan-academy" = {
+      required_services = ["cloudfunctions", "storage", "pubsub", "cloudbuild"]
+    }
+  }
+  
+  # Secrets that both service accounts need access to
+  secret_ids = [
+    "projects/khan-academy/secrets/api-key",
+    "projects/khan-academy/secrets/database-url"
+  ]
+  
+  # Terraform state bucket defaults to: terraform-khan-api-api-prod
 }
 ```

--- a/terraform/modules/github-ci-bootstrap/README.md
+++ b/terraform/modules/github-ci-bootstrap/README.md
@@ -207,10 +207,10 @@ Each `service_name` gets its own isolated:
 
 | Name | Description |
 |------|-------------|
-| `service_account_email` | Email of the created service account (write-enabled branches) |
-| `service_account_email_pr` | Email of the created service account (read-only, available to any branch) |
-| `workload_identity_provider` | Full resource name of the Workload Identity provider (write-enabled branches) |
-| `workload_identity_provider_pr` | Full resource name of the Workload Identity provider (read-only, available to any branch) |
+| `service_account_email_rw` | Email of the created service account (write-enabled branches) |
+| `service_account_email_ro` | Email of the created service account (read-only, available to any branch) |
+| `workload_identity_provider_rw` | Full resource name of the Workload Identity provider (write-enabled branches) |
+| `workload_identity_provider_ro` | Full resource name of the Workload Identity provider (read-only, available to any branch) |
 | `terraform_state_bucket` | The GCS bucket name used for Terraform state (computed or provided) |
 | `service_name` | The unique identifier for this Terraform configuration and environment |
 | `target_projects` | Map of target projects configured |
@@ -218,7 +218,7 @@ Each `service_name` gets its own isolated:
 
 ## GitHub Actions Configuration
 
-After applying this module, configure your GitHub Actions workflow to manage Terraform in CI. The module creates two service accounts, so you need to conditionally use different service accounts based on the branch:
+After applying this module, configure your GitHub Actions workflow to manage Terraform in CI. The module creates two service accounts, so you need to conditionally use different service accounts based on the branch. Note, in these examples the `outputs.xyz` vars should be replaced directly with the output values:
 
 ```yaml
 permissions:
@@ -235,14 +235,15 @@ jobs:
         if: contains(fromJSON('["refs/heads/main", "refs/heads/master"]'), github.ref)
         uses: google-github-actions/auth@v2
         with:
-          workload_identity_provider: ${{ outputs.workload_identity_provider }}
-          service_account: ${{ outputs.service_account_email }}
+          workload_identity_provider: ${{ outputs.workload_identity_provider_rw }}
+          service_account: ${{ outputs.service_account_email_rw }}
           
-      - name: Authenticate to Google Cloud (Read-Only - Any Branch)
+      - name: Authenticate to Google Cloud (Read-Only)
+        if: !contains(fromJSON('["refs/heads/main", "refs/heads/master"]'), github.ref)
         uses: google-github-actions/auth@v2
         with:
-          workload_identity_provider: ${{ outputs.workload_identity_provider_pr }}
-          service_account: ${{ outputs.service_account_email_pr }}
+          workload_identity_provider: ${{ outputs.workload_identity_provider_ro }}
+          service_account: ${{ outputs.service_account_email_ro }}
           
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2

--- a/terraform/modules/github-ci-bootstrap/examples/bootstrap-with-module/main.tf
+++ b/terraform/modules/github-ci-bootstrap/examples/bootstrap-with-module/main.tf
@@ -31,6 +31,9 @@ module "culture_cron_bootstrap" {
   service_name      = "culture-cron-prod"
   github_repository = "Khan/culture-cron"
 
+  # Configure which branches can use the write-enabled service account (defaults to main and master)
+  write_branch_patterns = ["main", "master"]
+
   # Target projects - culture-cron deploys to khan-internal-services
   target_projects = {
     (var.project_id) = {

--- a/terraform/modules/github-ci-bootstrap/examples/bootstrap-with-module/outputs.tf
+++ b/terraform/modules/github-ci-bootstrap/examples/bootstrap-with-module/outputs.tf
@@ -1,13 +1,23 @@
 # Outputs from the bootstrap example
 
-output "service_account_email" {
-  description = "Email address of the created service account for GitHub Actions"
-  value       = module.culture_cron_bootstrap.service_account_email
+output "service_account_email_rw" {
+  description = "Email address of the read-write service account for GitHub Actions (write-enabled branches)"
+  value       = module.culture_cron_bootstrap.service_account_email_rw
 }
 
-output "workload_identity_provider" {
-  description = "Full resource name of the Workload Identity provider for GitHub Actions"
-  value       = module.culture_cron_bootstrap.workload_identity_provider
+output "service_account_email_ro" {
+  description = "Email address of the read-only service account for GitHub Actions (available to any branch)"
+  value       = module.culture_cron_bootstrap.service_account_email_ro
+}
+
+output "workload_identity_provider_rw" {
+  description = "Full resource name of the read-write Workload Identity provider for GitHub Actions (write-enabled branches)"
+  value       = module.culture_cron_bootstrap.workload_identity_provider_rw
+}
+
+output "workload_identity_provider_ro" {
+  description = "Full resource name of the read-only Workload Identity provider for GitHub Actions (available to any branch)"
+  value       = module.culture_cron_bootstrap.workload_identity_provider_ro
 }
 
 output "service_name" {
@@ -23,4 +33,10 @@ output "github_repository" {
 output "target_projects" {
   description = "Map of target projects configured for this service account"
   value       = module.culture_cron_bootstrap.target_projects
+}
+
+
+output "write_branch_patterns" {
+  description = "List of branch patterns that are allowed to use the read/write service account"
+  value       = module.culture_cron_bootstrap.write_branch_patterns
 } 

--- a/terraform/modules/github-ci-bootstrap/main.tf
+++ b/terraform/modules/github-ci-bootstrap/main.tf
@@ -45,10 +45,10 @@ locals {
   terraform_state_bucket = coalesce(var.terraform_state_bucket, local.default_bucket_name)
 
   # Flatten target_projects into individual service permissions for read-write access
-  project_service_permissions = flatten([
+  project_service_permissions_rw = flatten([
     for project_id, config in var.target_projects : [
       for service in config.required_services : {
-        key        = "${project_id}-${service}"
+        key        = "${project_id}-${service}-rw"
         project_id = project_id
         service    = service
         role       = local.read_write_roles[service]
@@ -57,10 +57,10 @@ locals {
   ])
 
   # Flatten target_projects into individual service permissions for read-only access
-  project_service_permissions_readonly = flatten([
+  project_service_permissions_ro = flatten([
     for project_id, config in var.target_projects : [
       for service in config.required_services : {
-        key        = "${project_id}-${service}-readonly"
+        key        = "${project_id}-${service}-ro"
         project_id = project_id
         service    = service
         role       = local.read_only_roles[service]
@@ -86,9 +86,9 @@ resource "google_service_account" "github_ci_ro" {
 # === CROSS-PROJECT PERMISSIONS ===
 
 # Service-specific permissions across target projects (read-write access)
-resource "google_project_iam_member" "ci_service_permissions" {
+resource "google_project_iam_member" "ci_service_permissions_rw" {
   for_each = {
-    for perm in local.project_service_permissions : perm.key => perm
+    for perm in local.project_service_permissions_rw : perm.key => perm
   }
 
   project = each.value.project_id
@@ -99,7 +99,7 @@ resource "google_project_iam_member" "ci_service_permissions" {
 # Service-specific permissions across target projects (read-only access)
 resource "google_project_iam_member" "ci_service_permissions_ro" {
   for_each = {
-    for perm in local.project_service_permissions_readonly : perm.key => perm
+    for perm in local.project_service_permissions_ro : perm.key => perm
   }
 
   project = each.value.project_id
@@ -108,7 +108,7 @@ resource "google_project_iam_member" "ci_service_permissions_ro" {
 }
 
 # Cloud Functions requires service account user role (read-write access)
-resource "google_project_iam_member" "ci_sa_user" {
+resource "google_project_iam_member" "ci_sa_user_rw" {
   for_each = {
     for project_id, config in var.target_projects : project_id => config
     if contains(config.required_services, "cloudfunctions")
@@ -123,7 +123,7 @@ resource "google_project_iam_member" "ci_sa_user" {
 # Note: Read-only access doesn't need service account user role since it can't create/delete service accounts
 
 # Allow creating and deleting service accounts (needed for Terraform - read-write access only)
-resource "google_project_iam_member" "ci_sa_admin" {
+resource "google_project_iam_member" "ci_sa_admin_rw" {
   for_each = var.target_projects
 
   project = each.key
@@ -132,7 +132,7 @@ resource "google_project_iam_member" "ci_sa_admin" {
 }
 
 # Allow reading service accounts (needed for Terraform - read-only access)
-resource "google_project_iam_member" "ci_sa_viewer" {
+resource "google_project_iam_member" "ci_sa_viewer_ro" {
   for_each = var.target_projects
 
   project = each.key
@@ -141,7 +141,7 @@ resource "google_project_iam_member" "ci_sa_viewer" {
 }
 
 # Allow reading project information and IAM policies (needed for Terraform - read-only access)
-resource "google_project_iam_member" "ci_project_viewer" {
+resource "google_project_iam_member" "ci_project_viewer_ro" {
   for_each = var.target_projects
 
   project = each.key
@@ -150,7 +150,7 @@ resource "google_project_iam_member" "ci_project_viewer" {
 }
 
 # Allow creating IAM bindings (e.g. google_project_iam_member - read-write access only)
-resource "google_project_iam_member" "ci_iam_admin" {
+resource "google_project_iam_member" "ci_iam_admin_rw" {
   for_each = var.target_projects
 
   project = each.key
@@ -161,19 +161,13 @@ resource "google_project_iam_member" "ci_iam_admin" {
 # === TERRAFORM STATE BUCKET ACCESS ===
 
 # Access to Terraform state bucket (read-write access - full access)
-resource "google_storage_bucket_iam_member" "ci_state_bucket_access" {
+resource "google_storage_bucket_iam_member" "ci_state_bucket_access_rw" {
   bucket = local.terraform_state_bucket
   role   = "roles/storage.objectAdmin"
   member = "serviceAccount:${google_service_account.github_ci_rw.email}"
 }
 
-resource "google_storage_bucket_iam_member" "ci_state_bucket_reader" {
-  bucket = local.terraform_state_bucket
-  role   = "roles/storage.legacyBucketReader"
-  member = "serviceAccount:${google_service_account.github_ci_rw.email}"
-}
-
-resource "google_storage_bucket_iam_member" "ci_storage_legacy_bucket_owner" {
+resource "google_storage_bucket_iam_member" "ci_storage_legacy_bucket_owner_rw" {
   bucket = local.terraform_state_bucket
   role   = "roles/storage.legacyBucketOwner"
   member = "serviceAccount:${google_service_account.github_ci_rw.email}"
@@ -195,7 +189,7 @@ resource "google_storage_bucket_iam_member" "ci_state_bucket_legacy_reader_ro" {
 # === SECRET MANAGER ===
 
 # Dynamic secret admin access based on provided secret IDs (read-write access)
-resource "google_secret_manager_secret_iam_member" "ci_secret_admin" {
+resource "google_secret_manager_secret_iam_member" "ci_secret_admin_rw" {
   for_each  = toset(var.secret_ids)
   project   = var.secrets_project_id
   secret_id = each.value
@@ -244,9 +238,11 @@ resource "google_iam_workload_identity_pool" "github_ci_pool" {
 
 # Workload Identity Provider for read-write branches
 resource "google_iam_workload_identity_pool_provider" "github_ci_provider_rw" {
-  provider                           = google
-  project                            = data.google_project.khan_internal_services.number
-  workload_identity_pool_id          = google_iam_workload_identity_pool.github_ci_pool.workload_identity_pool_id
+  provider                  = google
+  project                   = data.google_project.khan_internal_services.number
+  workload_identity_pool_id = google_iam_workload_identity_pool.github_ci_pool.workload_identity_pool_id
+  # There's a max length of 32 characters for the workload identity pool provider ID
+  # In order to prevent name collisions, we use the SHA256 hash of the service name
   workload_identity_pool_provider_id = "${substr(sha256(var.service_name), 0, 8)}-rw"
   display_name                       = substr("${var.service_name} GitHub (read/write)", 0, 32)
   attribute_mapping = {
@@ -263,9 +259,11 @@ resource "google_iam_workload_identity_pool_provider" "github_ci_provider_rw" {
 
 # Workload Identity Provider for read-only access
 resource "google_iam_workload_identity_pool_provider" "github_ci_provider_ro" {
-  provider                           = google
-  project                            = data.google_project.khan_internal_services.number
-  workload_identity_pool_id          = google_iam_workload_identity_pool.github_ci_pool.workload_identity_pool_id
+  provider                  = google
+  project                   = data.google_project.khan_internal_services.number
+  workload_identity_pool_id = google_iam_workload_identity_pool.github_ci_pool.workload_identity_pool_id
+  # There's a max length of 32 characters for the workload identity pool provider ID
+  # In order to prevent name collisions, we use the SHA256 hash of the service name
   workload_identity_pool_provider_id = "${substr(sha256(var.service_name), 0, 8)}-ro"
   display_name                       = substr("${var.service_name} GitHub (read-only)", 0, 32)
   attribute_mapping = {

--- a/terraform/modules/github-ci-bootstrap/main.tf
+++ b/terraform/modules/github-ci-bootstrap/main.tf
@@ -14,13 +14,23 @@ terraform {
 
 # Define service-to-role mapping
 locals {
-  service_roles = {
+  read_write_roles = {
     cloudfunctions = "roles/cloudfunctions.admin"
     storage        = "roles/storage.admin"
     pubsub         = "roles/pubsub.admin"
     scheduler      = "roles/cloudscheduler.admin"
     run            = "roles/run.admin"
     cloudbuild     = "roles/cloudbuild.builds.builder"
+  }
+
+  # Read-only roles for any branch
+  read_only_roles = {
+    cloudfunctions = "roles/cloudfunctions.viewer"
+    storage        = "roles/storage.objectViewer"
+    pubsub         = "roles/pubsub.viewer"
+    scheduler      = "roles/cloudscheduler.viewer"
+    run            = "roles/run.viewer"
+    cloudbuild     = "roles/cloudbuild.builds.builder" # Read-only branches still need build access
   }
 
   # Parse GitHub repository into org and repo name
@@ -34,29 +44,48 @@ locals {
   # Use provided bucket name or computed default
   terraform_state_bucket = coalesce(var.terraform_state_bucket, local.default_bucket_name)
 
-  # Flatten target_projects into individual service permissions
+  # Flatten target_projects into individual service permissions for read-write access
   project_service_permissions = flatten([
     for project_id, config in var.target_projects : [
       for service in config.required_services : {
         key        = "${project_id}-${service}"
         project_id = project_id
         service    = service
-        role       = local.service_roles[service]
+        role       = local.read_write_roles[service]
+      }
+    ]
+  ])
+
+  # Flatten target_projects into individual service permissions for read-only access
+  project_service_permissions_readonly = flatten([
+    for project_id, config in var.target_projects : [
+      for service in config.required_services : {
+        key        = "${project_id}-${service}-readonly"
+        project_id = project_id
+        service    = service
+        role       = local.read_only_roles[service]
       }
     ]
   ])
 }
 
-# Service account for GitHub Actions (always created in khan-internal-services)
-resource "google_service_account" "github_ci" {
-  account_id   = "${var.service_name}-ci"
-  display_name = "GitHub CI for ${var.service_name}"
+# Service account for GitHub Actions write-enabled branches (always created in khan-internal-services)
+resource "google_service_account" "github_ci_rw" {
+  account_id   = "${var.service_name}-ci-rw"
+  display_name = "GitHub CI for ${var.service_name} (read-write)"
+  project      = "khan-internal-services"
+}
+
+# Service account for GitHub Actions read-only access (available to any branch)
+resource "google_service_account" "github_ci_ro" {
+  account_id   = "${var.service_name}-ci-ro"
+  display_name = "GitHub CI for ${var.service_name} (read-only)"
   project      = "khan-internal-services"
 }
 
 # === CROSS-PROJECT PERMISSIONS ===
 
-# Service-specific permissions across target projects
+# Service-specific permissions across target projects (read-write access)
 resource "google_project_iam_member" "ci_service_permissions" {
   for_each = {
     for perm in local.project_service_permissions : perm.key => perm
@@ -64,10 +93,21 @@ resource "google_project_iam_member" "ci_service_permissions" {
 
   project = each.value.project_id
   role    = each.value.role
-  member  = "serviceAccount:${google_service_account.github_ci.email}"
+  member  = "serviceAccount:${google_service_account.github_ci_rw.email}"
 }
 
-# Cloud Functions requires service account user role
+# Service-specific permissions across target projects (read-only access)
+resource "google_project_iam_member" "ci_service_permissions_ro" {
+  for_each = {
+    for perm in local.project_service_permissions_readonly : perm.key => perm
+  }
+
+  project = each.value.project_id
+  role    = each.value.role
+  member  = "serviceAccount:${google_service_account.github_ci_ro.email}"
+}
+
+# Cloud Functions requires service account user role (read-write access)
 resource "google_project_iam_member" "ci_sa_user" {
   for_each = {
     for project_id, config in var.target_projects : project_id => config
@@ -76,57 +116,109 @@ resource "google_project_iam_member" "ci_sa_user" {
 
   project = each.key
   role    = "roles/iam.serviceAccountUser"
-  member  = "serviceAccount:${google_service_account.github_ci.email}"
+  member  = "serviceAccount:${google_service_account.github_ci_rw.email}"
 }
 
-# Allow creating and deleting service accounts (needed for Terraform)
+# Cloud Functions requires service account user role (read-only access - no service account user needed)
+# Note: Read-only access doesn't need service account user role since it can't create/delete service accounts
+
+# Allow creating and deleting service accounts (needed for Terraform - read-write access only)
 resource "google_project_iam_member" "ci_sa_admin" {
   for_each = var.target_projects
 
   project = each.key
   role    = "roles/iam.serviceAccountAdmin"
-  member  = "serviceAccount:${google_service_account.github_ci.email}"
+  member  = "serviceAccount:${google_service_account.github_ci_rw.email}"
 }
 
-# Allow creating IAM bindings (e.g. google_project_iam_member)
+# Allow reading service accounts (needed for Terraform - read-only access)
+resource "google_project_iam_member" "ci_sa_viewer" {
+  for_each = var.target_projects
+
+  project = each.key
+  role    = "roles/iam.serviceAccountViewer"
+  member  = "serviceAccount:${google_service_account.github_ci_ro.email}"
+}
+
+# Allow reading project information and IAM policies (needed for Terraform - read-only access)
+resource "google_project_iam_member" "ci_project_viewer" {
+  for_each = var.target_projects
+
+  project = each.key
+  role    = "roles/viewer"
+  member  = "serviceAccount:${google_service_account.github_ci_ro.email}"
+}
+
+# Allow creating IAM bindings (e.g. google_project_iam_member - read-write access only)
 resource "google_project_iam_member" "ci_iam_admin" {
   for_each = var.target_projects
 
   project = each.key
   role    = "roles/resourcemanager.projectIamAdmin"
-  member  = "serviceAccount:${google_service_account.github_ci.email}"
+  member  = "serviceAccount:${google_service_account.github_ci_rw.email}"
 }
 
 # === TERRAFORM STATE BUCKET ACCESS ===
 
-# Access to Terraform state bucket
+# Access to Terraform state bucket (read-write access - full access)
 resource "google_storage_bucket_iam_member" "ci_state_bucket_access" {
   bucket = local.terraform_state_bucket
   role   = "roles/storage.objectAdmin"
-  member = "serviceAccount:${google_service_account.github_ci.email}"
+  member = "serviceAccount:${google_service_account.github_ci_rw.email}"
 }
 
 resource "google_storage_bucket_iam_member" "ci_state_bucket_reader" {
   bucket = local.terraform_state_bucket
   role   = "roles/storage.legacyBucketReader"
-  member = "serviceAccount:${google_service_account.github_ci.email}"
+  member = "serviceAccount:${google_service_account.github_ci_rw.email}"
 }
 
 resource "google_storage_bucket_iam_member" "ci_storage_legacy_bucket_owner" {
   bucket = local.terraform_state_bucket
   role   = "roles/storage.legacyBucketOwner"
-  member = "serviceAccount:${google_service_account.github_ci.email}"
+  member = "serviceAccount:${google_service_account.github_ci_rw.email}"
+}
+
+# Access to Terraform state bucket (read-only access)
+resource "google_storage_bucket_iam_member" "ci_state_bucket_reader_ro" {
+  bucket = local.terraform_state_bucket
+  role   = "roles/storage.objectViewer"
+  member = "serviceAccount:${google_service_account.github_ci_ro.email}"
+}
+
+resource "google_storage_bucket_iam_member" "ci_state_bucket_legacy_reader_ro" {
+  bucket = local.terraform_state_bucket
+  role   = "roles/storage.legacyBucketReader"
+  member = "serviceAccount:${google_service_account.github_ci_ro.email}"
 }
 
 # === SECRET MANAGER ===
 
-# Dynamic secret admin access based on provided secret IDs
+# Dynamic secret admin access based on provided secret IDs (read-write access)
 resource "google_secret_manager_secret_iam_member" "ci_secret_admin" {
   for_each  = toset(var.secret_ids)
   project   = var.secrets_project_id
   secret_id = each.value
   role      = "roles/secretmanager.admin"
-  member    = "serviceAccount:${google_service_account.github_ci.email}"
+  member    = "serviceAccount:${google_service_account.github_ci_rw.email}"
+}
+
+# Dynamic secret accessor access for read-only access
+resource "google_secret_manager_secret_iam_member" "ci_secret_accessor_ro" {
+  for_each  = toset(var.secret_ids)
+  project   = var.secrets_project_id
+  secret_id = each.value
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.github_ci_ro.email}"
+}
+
+# Allow reading secret IAM policies (needed for Terraform - read-only access)
+resource "google_secret_manager_secret_iam_member" "ci_secret_viewer_ro" {
+  for_each  = toset(var.secret_ids)
+  project   = var.secrets_project_id
+  secret_id = each.value
+  role      = "roles/secretmanager.viewer"
+  member    = "serviceAccount:${google_service_account.github_ci_ro.email}"
 }
 
 # === WORKLOAD IDENTITY FEDERATION FOR GITHUB CI ===
@@ -150,17 +242,37 @@ resource "google_iam_workload_identity_pool" "github_ci_pool" {
   }
 }
 
-# Workload Identity Provider for this specific service
-resource "google_iam_workload_identity_pool_provider" "github_ci_provider" {
+# Workload Identity Provider for read-write branches
+resource "google_iam_workload_identity_pool_provider" "github_ci_provider_rw" {
   provider                           = google
   project                            = data.google_project.khan_internal_services.number
   workload_identity_pool_id          = google_iam_workload_identity_pool.github_ci_pool.workload_identity_pool_id
-  workload_identity_pool_provider_id = "${var.service_name}-provider"
-  display_name                       = substr("${var.service_name} GitHub", 0, 32)
+  workload_identity_pool_provider_id = "${substr(sha256(var.service_name), 0, 8)}-rw"
+  display_name                       = substr("${var.service_name} GitHub (read/write)", 0, 32)
   attribute_mapping = {
     "google.subject"       = "assertion.sub"
     "attribute.repository" = "assertion.repository"
     "attribute.actor"      = "assertion.actor"
+    "attribute.ref"        = "assertion.ref"
+  }
+  oidc {
+    issuer_uri = "https://token.actions.githubusercontent.com"
+  }
+  attribute_condition = "attribute.repository == \"${var.github_repository}\" && (${join(" || ", [for pattern in var.write_branch_patterns : "attribute.ref == \"refs/heads/${pattern}\""])})"
+}
+
+# Workload Identity Provider for read-only access
+resource "google_iam_workload_identity_pool_provider" "github_ci_provider_ro" {
+  provider                           = google
+  project                            = data.google_project.khan_internal_services.number
+  workload_identity_pool_id          = google_iam_workload_identity_pool.github_ci_pool.workload_identity_pool_id
+  workload_identity_pool_provider_id = "${substr(sha256(var.service_name), 0, 8)}-ro"
+  display_name                       = substr("${var.service_name} GitHub (read-only)", 0, 32)
+  attribute_mapping = {
+    "google.subject"       = "assertion.sub"
+    "attribute.repository" = "assertion.repository"
+    "attribute.actor"      = "assertion.actor"
+    "attribute.ref"        = "assertion.ref"
   }
   oidc {
     issuer_uri = "https://token.actions.githubusercontent.com"
@@ -168,9 +280,16 @@ resource "google_iam_workload_identity_pool_provider" "github_ci_provider" {
   attribute_condition = "attribute.repository == \"${var.github_repository}\""
 }
 
-# Bind the service account to the Workload Identity provider
-resource "google_service_account_iam_member" "github_ci_identity_binding" {
-  service_account_id = google_service_account.github_ci.name
+# Bind the read-write service account to the Workload Identity provider
+resource "google_service_account_iam_member" "github_ci_identity_binding_rw" {
+  service_account_id = google_service_account.github_ci_rw.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "principalSet://iam.googleapis.com/projects/${data.google_project.khan_internal_services.number}/locations/global/workloadIdentityPools/${google_iam_workload_identity_pool.github_ci_pool.workload_identity_pool_id}/attribute.repository/${var.github_repository}"
+}
+
+# Bind the read-only service account to the Workload Identity provider
+resource "google_service_account_iam_member" "github_ci_identity_binding_ro" {
+  service_account_id = google_service_account.github_ci_ro.name
   role               = "roles/iam.workloadIdentityUser"
   member             = "principalSet://iam.googleapis.com/projects/${data.google_project.khan_internal_services.number}/locations/global/workloadIdentityPools/${google_iam_workload_identity_pool.github_ci_pool.workload_identity_pool_id}/attribute.repository/${var.github_repository}"
 }

--- a/terraform/modules/github-ci-bootstrap/outputs.tf
+++ b/terraform/modules/github-ci-bootstrap/outputs.tf
@@ -70,14 +70,3 @@ output "write_branch_patterns" {
   description = "List of branch patterns that are allowed to use the read/write service account"
   value       = var.write_branch_patterns
 }
-
-# Additional outputs for backward compatibility and clarity
-output "terraform_service_account_email" {
-  description = "Email address of the read-write service account (alias for service_account_email_rw)"
-  value       = google_service_account.github_ci_rw.email
-}
-
-output "workload_identity_provider" {
-  description = "Full resource name of the read-write Workload Identity provider (alias for workload_identity_provider_rw)"
-  value       = "projects/${data.google_project.khan_internal_services.number}/locations/global/workloadIdentityPools/${google_iam_workload_identity_pool.github_ci_pool.workload_identity_pool_id}/providers/${google_iam_workload_identity_pool_provider.github_ci_provider_rw.workload_identity_pool_provider_id}"
-} 

--- a/terraform/modules/github-ci-bootstrap/outputs.tf
+++ b/terraform/modules/github-ci-bootstrap/outputs.tf
@@ -1,18 +1,33 @@
 # Outputs from the GitHub Terraform CI Bootstrap module
 
-output "service_account_email" {
-  description = "Email address of the created service account for GitHub Actions"
-  value       = google_service_account.github_ci.email
+output "service_account_email_rw" {
+  description = "Email address of the read-write service account for GitHub Actions (write-enabled branches)"
+  value       = google_service_account.github_ci_rw.email
 }
 
-output "service_account_name" {
-  description = "Full resource name of the created service account"
-  value       = google_service_account.github_ci.name
+output "service_account_name_rw" {
+  description = "Full resource name of the read-write service account (write-enabled branches)"
+  value       = google_service_account.github_ci_rw.name
 }
 
-output "workload_identity_provider" {
-  description = "Full resource name of the Workload Identity provider for GitHub Actions"
-  value       = "projects/${data.google_project.khan_internal_services.number}/locations/global/workloadIdentityPools/${google_iam_workload_identity_pool.github_ci_pool.workload_identity_pool_id}/providers/${google_iam_workload_identity_pool_provider.github_ci_provider.workload_identity_pool_provider_id}"
+output "service_account_email_ro" {
+  description = "Email address of the read-only service account for GitHub Actions (available to any branch)"
+  value       = google_service_account.github_ci_ro.email
+}
+
+output "service_account_name_ro" {
+  description = "Full resource name of the read-only service account (available to any branch)"
+  value       = google_service_account.github_ci_ro.name
+}
+
+output "workload_identity_provider_rw" {
+  description = "Full resource name of the read-write Workload Identity provider for GitHub Actions (write-enabled branches)"
+  value       = "projects/${data.google_project.khan_internal_services.number}/locations/global/workloadIdentityPools/${google_iam_workload_identity_pool.github_ci_pool.workload_identity_pool_id}/providers/${google_iam_workload_identity_pool_provider.github_ci_provider_rw.workload_identity_pool_provider_id}"
+}
+
+output "workload_identity_provider_ro" {
+  description = "Full resource name of the read-only Workload Identity provider for GitHub Actions (available to any branch)"
+  value       = "projects/${data.google_project.khan_internal_services.number}/locations/global/workloadIdentityPools/${google_iam_workload_identity_pool.github_ci_pool.workload_identity_pool_id}/providers/${google_iam_workload_identity_pool_provider.github_ci_provider_ro.workload_identity_pool_provider_id}"
 }
 
 output "workload_identity_pool_id" {
@@ -20,9 +35,14 @@ output "workload_identity_pool_id" {
   value       = google_iam_workload_identity_pool.github_ci_pool.workload_identity_pool_id
 }
 
-output "workload_identity_provider_id" {
-  description = "ID of the Workload Identity provider for this service"
-  value       = google_iam_workload_identity_pool_provider.github_ci_provider.workload_identity_pool_provider_id
+output "workload_identity_provider_id_rw" {
+  description = "ID of the read-write Workload Identity provider for this service (write-enabled branches)"
+  value       = google_iam_workload_identity_pool_provider.github_ci_provider_rw.workload_identity_pool_provider_id
+}
+
+output "workload_identity_provider_id_ro" {
+  description = "ID of the read-only Workload Identity provider for this service (available to any branch)"
+  value       = google_iam_workload_identity_pool_provider.github_ci_provider_ro.workload_identity_pool_provider_id
 }
 
 output "terraform_state_bucket" {
@@ -43,4 +63,21 @@ output "github_repository" {
 output "target_projects" {
   description = "Map of target projects configured for this service account"
   value       = var.target_projects
+}
+
+
+output "write_branch_patterns" {
+  description = "List of branch patterns that are allowed to use the read/write service account"
+  value       = var.write_branch_patterns
+}
+
+# Additional outputs for backward compatibility and clarity
+output "terraform_service_account_email" {
+  description = "Email address of the read-write service account (alias for service_account_email_rw)"
+  value       = google_service_account.github_ci_rw.email
+}
+
+output "workload_identity_provider" {
+  description = "Full resource name of the read-write Workload Identity provider (alias for workload_identity_provider_rw)"
+  value       = "projects/${data.google_project.khan_internal_services.number}/locations/global/workloadIdentityPools/${google_iam_workload_identity_pool.github_ci_pool.workload_identity_pool_id}/providers/${google_iam_workload_identity_pool_provider.github_ci_provider_rw.workload_identity_pool_provider_id}"
 } 

--- a/terraform/modules/github-ci-bootstrap/variables.tf
+++ b/terraform/modules/github-ci-bootstrap/variables.tf
@@ -41,6 +41,13 @@ variable "target_projects" {
   }
 }
 
+
+variable "write_branch_patterns" {
+  description = "List of branch patterns that are allowed to use the read/write service account (defaults to main and master)"
+  type        = list(string)
+  default     = ["main", "master"]
+}
+
 variable "terraform_state_bucket" {
   description = "GCS bucket name for storing Terraform state (defaults to terraform-{org}-{repo}-{service})"
   type        = string


### PR DESCRIPTION
## Summary:

Currently, Terraform PR checks run with the "prod" deploy service account, which poses a significant security risk. If GitHub Actions workflows are modified to run `terraform apply` instead of just `terraform plan`, PRs could inadvertently make changes to production infrastructure. This violates the principle of least privilege and creates potential for accidental production deployments.

## Solution

This PR introduces **dual service account support** to the `github-ci-bootstrap` module, always creating two separate service accounts with different permission levels:

1. **Write-Enabled Service Account** (`{service_name}-ci`): Full admin permissions for specified branches (defaults to `main` and `master`)
2. **Read-Only Service Account** (`{service_name}-ci-pr`): Read-only permissions available to any branch, with Cloud Build access for validation

## Key Changes

### New Variables
- `write_branch_patterns` (list(string), default: `["main", "master"]`): Specifies which branches can use the write-enabled service account

### Permission Differences

| Service | Write-Enabled Branches | Read-Only Service Account |
|---------|----------------------|---------------------------|
| Cloud Functions | `roles/cloudfunctions.admin` | `roles/cloudfunctions.viewer` |
| Storage | `roles/storage.admin` | `roles/storage.objectViewer` |
| Pub/Sub | `roles/pubsub.admin` | `roles/pubsub.viewer` |
| Scheduler | `roles/cloudscheduler.admin` | `roles/cloudscheduler.viewer` |
| Cloud Run | `roles/run.admin` | `roles/run.viewer` |
| Cloud Build | `roles/cloudbuild.builds.builder` | `roles/cloudbuild.builds.builder` |
| Secret Manager | `roles/secretmanager.admin` | `roles/secretmanager.secretAccessor` |
| Terraform State | `roles/storage.objectAdmin` | `roles/storage.objectViewer` |

### Workload Identity Federation Updates
- **Write-Enabled Provider**: Only works on branches specified in `write_branch_patterns`
- **Read-Only Provider**: Works on any branch in the repository (safe to use anywhere)
- Secure by default: only explicitly specified branches can make infrastructure changes

## Security Benefits

1. **Principle of Least Privilege**: PR branches can only read resources and run builds
2. **Accidental Deployment Prevention**: PRs cannot modify infrastructure even if workflows are changed
3. **Secure by Default**: Only explicitly specified branches can make changes
4. **Audit Trail**: Clear separation between read-only validation and write operations

## Usage Example

```hcl
module "my_service_ci" {
  source = "git::https://github.com/Khan/terraform-modules.git//terraform/modules/github-ci-bootstrap?ref=v1.0.0"

  service_name      = "my-service-prod"
  github_repository = "Khan/my-service"
  
  # Only main and master branches can deploy (secure default)
  write_branch_patterns = ["main", "master"]
  
  target_projects = {
    "khan-academy" = {
      required_services = ["cloudfunctions", "storage", "pubsub", "cloudbuild"]
    }
  }
}
```

## GitHub Actions Configuration

With dual service accounts, for terraform deploys using our shared terraform github actions, the service account references will need to be update. The `generate-terraform-plan` action will need to use the `read-only` service account. The `apply-terraform-plan` action will need to use the `read-write` account.

## Files Changed

- `variables.tf`: Removed `enable_dual_service_accounts` variable, added `write_branch_patterns`
- `main.tf`: Always creates both service accounts with appropriate permissions
- `outputs.tf`: Always outputs both service account details
- `README.md`: Updated documentation to reflect always-on dual service accounts
- `examples/`: Updated example configurations

## Migration Guide

For existing deployments:

1. Update module configuration:
   ```hcl
   write_branch_patterns = ["main", "master"]  # or your preferred branches
   ```

2. Update GitHub Actions workflows to use conditional authentication (see example above)

3. Apply the Terraform changes

**Note**: This is a breaking change. Once updated, the module will now always create two service accounts instead of one.

This change significantly improves the security posture of our Terraform CI/CD pipelines by preventing accidental production deployments from PR branches.


Issue: INFRA-10749

## Test plan:
- [x] [Update the internal-webserver repo to use this](https://github.com/Khan/internal-webserver/pull/97)
- [x] Verified dual service account creation
- [x] Tested Workload Identity Federation with branch conditions
- [x] Confirmed permission differences between service accounts