### PR TITLE
[🔥AUDIT🔥] Add cloudbuild.builds.builder to ro github ci account

### DIFF
--- a/terraform/modules/github-ci-bootstrap/main.tf
+++ b/terraform/modules/github-ci-bootstrap/main.tf
@@ -15,30 +15,30 @@ terraform {
 # Define service-to-role mapping
 locals {
   read_write_roles = {
-    cloudfunctions     = "roles/cloudfunctions.admin"
-    storage            = "roles/storage.admin"
-    pubsub             = "roles/pubsub.admin"
-    scheduler          = "roles/cloudscheduler.admin"
-    run                = "roles/run.admin"
-    cloudbuild         = "roles/cloudbuild.admin"
-    artifactregistry   = "roles/artifactregistry.admin"
-    secretmanager      = "roles/secretmanager.admin"
-    logging            = "roles/logging.admin"
-    monitoring         = "roles/monitoring.admin"
+    cloudfunctions   = "roles/cloudfunctions.admin"
+    storage          = "roles/storage.admin"
+    pubsub           = "roles/pubsub.admin"
+    scheduler        = "roles/cloudscheduler.admin"
+    run              = "roles/run.admin"
+    cloudbuild       = "roles/cloudbuild.admin"
+    artifactregistry = "roles/artifactregistry.admin"
+    secretmanager    = "roles/secretmanager.admin"
+    logging          = "roles/logging.admin"
+    monitoring       = "roles/monitoring.admin"
   }
 
   # Read-only roles for any branch
   read_only_roles = {
-    cloudfunctions     = "roles/cloudfunctions.viewer"
-    storage            = "roles/storage.objectViewer"
-    pubsub             = "roles/pubsub.viewer"
-    scheduler          = "roles/cloudscheduler.viewer"
-    run                = "roles/run.viewer"
-    cloudbuild         = "roles/cloudbuild.viewer" # Read-only branches get viewer access
-    artifactregistry   = "roles/artifactregistry.reader"
-    secretmanager      = "roles/secretmanager.viewer"
-    logging            = "roles/logging.viewer"
-    monitoring         = "roles/monitoring.viewer"
+    cloudfunctions   = "roles/cloudfunctions.viewer"
+    storage          = "roles/storage.objectViewer"
+    pubsub           = "roles/pubsub.viewer"
+    scheduler        = "roles/cloudscheduler.viewer"
+    run              = "roles/run.viewer"
+    cloudbuild       = "roles/cloudbuild.builds.builder" # Read-only branches still need build access
+    artifactregistry = "roles/artifactregistry.reader"
+    secretmanager    = "roles/secretmanager.viewer"
+    logging          = "roles/logging.viewer"
+    monitoring       = "roles/monitoring.viewer"
   }
 
   # Parse GitHub repository into org and repo name

--- a/terraform/modules/github-ci-bootstrap/main.tf
+++ b/terraform/modules/github-ci-bootstrap/main.tf
@@ -20,7 +20,7 @@ locals {
     pubsub           = "roles/pubsub.admin"
     scheduler        = "roles/cloudscheduler.admin"
     run              = "roles/run.admin"
-    cloudbuild       = "roles/cloudbuild.admin"
+    cloudbuild       = "roles/cloudbuild.builds.builder"
     artifactregistry = "roles/artifactregistry.admin"
     secretmanager    = "roles/secretmanager.admin"
     logging          = "roles/logging.admin"


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
We still run cloud builds on PR branches, so the read-only account needs build permissions.

Issue: INFRA-XXXX

## Test plan:
Test it on [this branch](https://github.com/Khan/internal-services/pull/357)