### PR TITLE
[🔥AUDIT🔥] Update scheduled job function archive location

### DIFF
--- a/terraform/modules/scheduled-job/main.tf
+++ b/terraform/modules/scheduled-job/main.tf
@@ -54,9 +54,9 @@ data "archive_file" "function_archive" {
 resource "google_storage_bucket_object" "function_archive" {
   count = var.execution_type == "function" ? 1 : 0
 
-  name   = "${var.job_name}-function-${data.archive_file.function_archive[0].output_sha}.zip"
-  bucket = google_storage_bucket.function_bucket[0].name
-  source = data.archive_file.function_archive[0].output_path
+  name    = "${var.job_name}-function-${data.archive_file.function_archive[0].output_sha}.zip"
+  bucket  = google_storage_bucket.function_bucket[0].name
+  content = data.archive_file.function_archive[0].output_base64
 }
 
 # PubSub topic for triggering the Cloud Function (only created when execution_type is "function")


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
Since we run `plan` and `apply` as separate github actions, the zip generated during the `plan` isn't present for the `apply` action. I'm not sure how this ever worked.

Instead of passing along the filepath for the zip, pass along the contents. This means the file will effectively be included in the terraform plan binary, making it available during the apply stage.

Issue: INFRA-XXXX

## Test plan:
Update internal-webserver to use this branch, run an `apply`, the apply should work as expected.