### PR TITLE
[🔥AUDIT🔥] Ensure function archive is included in the tfplan bin

### DIFF
--- a/terraform/modules/scheduled-job/README.md
+++ b/terraform/modules/scheduled-job/README.md
@@ -413,3 +413,16 @@ gcloud builds submit --tag gcr.io/YOUR_PROJECT_ID/YOUR_JOB_NAME:latest ./jobs/yo
 | `"0 2 * * *"`    | 2 AM daily       |
 | `"0 9 * * 1"`    | Monday 9 AM      |
 | `"*/15 * * * *"` | Every 15 minutes |
+
+## CI/CD Considerations
+
+This module is designed to work seamlessly with CI/CD pipelines where `terraform plan` and `terraform apply` run as separate jobs with ephemeral storage.
+
+The module uses `filebase64()` to embed the function archive content directly in the Terraform plan file. This ensures that the archive content is available during the apply phase even when the original zip file no longer exists.
+
+**How it works:**
+
+1. During `plan`: The `archive_file` data source creates a zip file, and `filebase64()` reads it and embeds the content in the plan
+2. During `apply`: The embedded content from the plan is used to create the GCS object, no local files needed
+
+This approach eliminates the need for artifact management between CI jobs while keeping the module simple and reliable.

--- a/terraform/modules/scheduled-job/main.tf
+++ b/terraform/modules/scheduled-job/main.tf
@@ -54,9 +54,11 @@ data "archive_file" "function_archive" {
 resource "google_storage_bucket_object" "function_archive" {
   count = var.execution_type == "function" ? 1 : 0
 
-  name   = "${var.job_name}-function-${data.archive_file.function_archive[0].output_sha}.zip"
-  bucket = google_storage_bucket.function_bucket[0].name
-  source = data.archive_file.function_archive[0].output_path
+  name    = "${var.job_name}-function-${data.archive_file.function_archive[0].output_sha}.zip"
+  bucket  = google_storage_bucket.function_bucket[0].name
+  # Use filebase64 to embed the zip file content directly in the terraform plan
+  # This ensures the content is available during apply even in separate CI jobs
+  content = filebase64(data.archive_file.function_archive[0].output_path)
 }
 
 # PubSub topic for triggering the Cloud Function (only created when execution_type is "function")


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
Since we run `plan` and `apply` as separate github actions, the zip generated during the `plan` isn't present for the `apply` action. I'm not sure how this ever worked.

Instead of passing along the filepath for the zip, pass along the contents. This means the file will effectively be included in the terraform plan binary, making it available during the apply stage.

Issue: INFRA-XXXX

## Test plan:
Update internal-webserver to use this branch, run an `apply`, the apply should work as expected.