### PR TITLE
[🔥AUDIT🔥] Respect the retries_enabled flag for cloud run jobs

### DIFF
--- a/terraform/modules/scheduled-job/main.tf
+++ b/terraform/modules/scheduled-job/main.tf
@@ -249,6 +249,7 @@ resource "google_cloud_run_v2_job" "job" {
         }
       }
 
+      max_retries     = var.retries_enabled ? 3 : 0
       service_account = google_service_account.function_sa.email
       timeout         = var.job_timeout
     }


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
This was an oversight from the initial cloud run job implementation. Let's make sure the retries_enabled flag is respected for jobs.

Issue: INFRA-XXXX

## Test plan:
Fingers crossed. [See here for documentation of this field].