### PR TITLE
Update scheduled job and function to depend on secret access

### DIFF
--- a/terraform/modules/scheduled-job/main.tf
+++ b/terraform/modules/scheduled-job/main.tf
@@ -135,8 +135,11 @@ resource "google_cloudfunctions2_function" "function" {
   description = var.description
   location    = var.region
 
-  # Ensure service account is created before the function
-  depends_on = [google_service_account.function_sa]
+  # Ensure service account and secret access are created before the function
+  depends_on = [
+    google_service_account.function_sa,
+    google_secret_manager_secret_iam_member.function_secret_access
+  ]
 
   build_config {
     runtime     = var.runtime
@@ -197,8 +200,11 @@ resource "google_cloud_run_v2_job" "job" {
   # Allow Terraform to manage the job lifecycle
   deletion_protection = false
 
-  # Ensure service account is created before the job
-  depends_on = [google_service_account.function_sa]
+  # Ensure service account and secret access are created before the job
+  depends_on = [
+    google_service_account.function_sa,
+    google_secret_manager_secret_iam_member.function_secret_access
+  ]
 
   lifecycle {
     precondition {


### PR DESCRIPTION
## Summary:
Currently, the first `apply` after adding a new secret will often fail because the secret access is created as the same time as the job or function, so the job or function can fail to start due to lacking access to the secret. Having the job or function depend on the secred access should resolve that.

Issue: INFRA-10752

## Test plan:
I ran an apply with this on local in culture-cron and did no see any issues. Testing the actual timing issue is a bit tricker, so we'll just see if it comes up again.