### PR TITLE
cloud-build-docker: stop clobbering :latest on PR builds

### DIFF
--- a/terraform/modules/cloud-build-docker/cloudbuild.yml
+++ b/terraform/modules/cloud-build-docker/cloudbuild.yml
@@ -32,17 +32,11 @@ steps:
       --build-arg BASE_IMAGE="$_BASE_DIGEST" \
       .
 
-- name: 'gcr.io/cloud-builders/docker'
-  id: Tag cache image
-  entrypoint: bash
-  args: ['-c', 'docker tag "$_IMAGE_TAG" "$_IMAGE_NAME:$_CACHE_TAG"']
-  waitFor: ['Build image with BuildKit']
-
-- name: 'gcr.io/cloud-builders/docker'
-  id: Push cache image
-  entrypoint: bash
-  args: ['-c', 'docker push "$_IMAGE_NAME:$_CACHE_TAG"']
-  waitFor: ['Tag cache image']
-
+# Only push the build's own tag ($_IMAGE_TAG). Do NOT also push under
+# $_IMAGE_NAME:$_CACHE_TAG: that tag is chosen as a *read* fallback by
+# build_image.py (it falls back to "latest" when the requested tag does
+# not yet exist), and pushing the build under it would clobber whatever
+# is currently at that tag. In practice this would let a first-time PR
+# build overwrite the master image at :latest with its own content.
 images:
 - '$_IMAGE_TAG'


### PR DESCRIPTION
## Summary

The `cloud-build-docker` module's `cloudbuild.yml` has an explicit "Tag cache image" + "Push cache image" pair of steps that unconditionally pushes the freshly-built image under `$_IMAGE_NAME:$_CACHE_TAG`. That tag is chosen as a *read-side* fallback by `build_image.py:get_effective_cache_tag()` — it falls back to `"latest"` whenever the caller's requested `image_tag_suffix` doesn't yet exist in Artifact Registry. So a first-time PR build runs with:

```
_IMAGE_TAG  = $_IMAGE_NAME:revert-nfs   (intended: publish under :revert-nfs)
_CACHE_TAG  = latest                    (read-side fallback)
```

…and the cache push step then writes the PR's image content to `$_IMAGE_NAME:latest`, overwriting whatever master last pushed there.

The Tag/Push cache steps are redundant with the existing `images:` block, which already publishes `$_IMAGE_TAG` — canonical (master) builds still update `:latest` correctly via `images:`. The only effect of the removed steps was the clobber. `$_CACHE_TAG` continues to be used for the read side (`--cache-from`).

## Why this matters

This bug caused a perpetual drift loop on `Khan/internal-services`'s GitHub Actions Runner terraform config. The `data.external "build_image"` data source reads `:latest`'s digest into the plan; when concurrent PR + master plan workflows each pushed different image content to `:latest`, the apply workflow's chained re-plan kept seeing the runner image digest "change" even when nothing had actually been redeployed, opening repeated terraform-plan PRs.

Once this is merged, internal-services bumps `ref=cloud-build-docker-v0.2.0` (or v0.3.0) to the new tag.

## Test plan

- [ ] Tag a new release (e.g. `cloud-build-docker-v0.4.0`) after merging.
- [ ] In a consumer repo, bump the module `ref=` and run a PR plan against a branch whose tag doesn't yet exist in AR; confirm Cloud Build pushes only `$_IMAGE_TAG` (the branch tag) and does NOT also push `:latest`.
- [ ] Subsequent master push plan should be the only thing that updates `:latest`.