### PR TITLE
cloud-build-docker: reproducible image digests via buildx

### DIFF
--- a/terraform/modules/cloud-build-docker/cloudbuild.yml
+++ b/terraform/modules/cloud-build-docker/cloudbuild.yml
@@ -25,11 +25,20 @@ steps:
     # Build with BuildKit inline cache
     # --cache-from pulls cache metadata from previous build
     # --build-arg BUILDKIT_INLINE_CACHE=1 embeds cache metadata in the image
+    #
+    # SOURCE_DATE_EPOCH makes the resulting image digest reproducible. Without
+    # it, the Dockerfile frontend stamps the image config (the `created` field
+    # and every `history[].created` entry) with the current wall-clock time, so
+    # two builds of byte-identical content still produce different manifest
+    # digests. Anything pinning by digest (e.g. a Cloud Run job) then sees
+    # spurious "updates" on every rebuild. Pinning the epoch to a constant (0)
+    # clamps those timestamps so the digest changes only when content changes.
     docker build \
       --tag="$_IMAGE_TAG" \
       --cache-from="$_IMAGE_NAME:$_CACHE_TAG" \
       --build-arg BUILDKIT_INLINE_CACHE=1 \
       --build-arg BASE_IMAGE="$_BASE_DIGEST" \
+      --build-arg SOURCE_DATE_EPOCH=0 \
       .
 
 # Only push the build's own tag ($_IMAGE_TAG). Do NOT also push under

--- a/terraform/modules/cloud-build-docker/cloudbuild.yml
+++ b/terraform/modules/cloud-build-docker/cloudbuild.yml
@@ -1,51 +1,47 @@
-# Cloud Build configuration with BuildKit inline cache for multi-stage builds.
-# BuildKit is required to properly cache intermediate stages in multi-stage builds.
+# Cloud Build configuration: reproducible Docker image builds.
+#
+# Builds with `docker buildx` (BuildKit) using the docker-container driver,
+# which is required for the image exporter's `rewrite-timestamp` option.
+#
+# Why reproducible digests matter: the digest this build produces is pinned
+# directly into downstream resources (e.g. a Cloud Run job/service). If the
+# digest changes on a rebuild that didn't actually change image content,
+# every consumer sees spurious "updates" and drift. BuildKit by default
+# stamps the image config, the per-step `history` entries, and file mtimes
+# inside layers with wall-clock time, so byte-identical content yields a
+# different digest on every build.
+#
+# Three settings together make the digest a pure function of content:
+#   - SOURCE_DATE_EPOCH    clamps the config + history timestamps
+#   - rewrite-timestamp    clamps file mtimes inside the layer blobs
+#   - --provenance/--sbom  disabled; attestations embed build metadata
+#                          (timestamps, build IDs) that is non-deterministic
+#
+# Caching: layers are read from $_IMAGE_NAME:$_CACHE_TAG (build_image.py
+# falls back to "latest" when the requested tag does not yet exist) and the
+# cache is written inline into the image pushed under $_IMAGE_TAG. Only
+# $_IMAGE_TAG is ever pushed, so a build can never clobber another tag.
 steps:
 - name: 'gcr.io/cloud-builders/docker'
-  id: Pull cache images
+  id: Build and push image
   entrypoint: bash
   args:
   - -c
   - |
-    echo "Attempting to pull cache image..."
-    # With BuildKit inline cache, we only need to pull the final image
-    # which contains metadata about all intermediate stages
-    docker pull "$_IMAGE_NAME:$_CACHE_TAG" || echo "Cache image not found, building from scratch"
+    set -e
 
-- name: 'gcr.io/cloud-builders/docker'
-  id: Build image with BuildKit
-  entrypoint: bash
-  env:
-  - 'DOCKER_BUILDKIT=1'
-  args:
-  - -c
-  - |
-    echo "Building with BuildKit and inline cache..."
+    # The docker-container driver runs BuildKit in a container. It is
+    # required for the image exporter's rewrite-timestamp option; the
+    # default "docker" driver does not support it.
+    docker buildx create --name reproducible --driver docker-container --use
 
-    # Build with BuildKit inline cache
-    # --cache-from pulls cache metadata from previous build
-    # --build-arg BUILDKIT_INLINE_CACHE=1 embeds cache metadata in the image
-    #
-    # SOURCE_DATE_EPOCH makes the resulting image digest reproducible. Without
-    # it, the Dockerfile frontend stamps the image config (the `created` field
-    # and every `history[].created` entry) with the current wall-clock time, so
-    # two builds of byte-identical content still produce different manifest
-    # digests. Anything pinning by digest (e.g. a Cloud Run job) then sees
-    # spurious "updates" on every rebuild. Pinning the epoch to a constant (0)
-    # clamps those timestamps so the digest changes only when content changes.
-    docker build \
-      --tag="$_IMAGE_TAG" \
-      --cache-from="$_IMAGE_NAME:$_CACHE_TAG" \
-      --build-arg BUILDKIT_INLINE_CACHE=1 \
+    docker buildx build \
+      --builder reproducible \
       --build-arg BASE_IMAGE="$_BASE_DIGEST" \
       --build-arg SOURCE_DATE_EPOCH=0 \
+      --provenance=false \
+      --sbom=false \
+      --cache-from type=registry,ref="$_IMAGE_NAME:$_CACHE_TAG" \
+      --cache-to type=inline \
+      --output type=image,name="$_IMAGE_TAG",push=true,rewrite-timestamp=true \
       .
-
-# Only push the build's own tag ($_IMAGE_TAG). Do NOT also push under
-# $_IMAGE_NAME:$_CACHE_TAG: that tag is chosen as a *read* fallback by
-# build_image.py (it falls back to "latest" when the requested tag does
-# not yet exist), and pushing the build under it would clobber whatever
-# is currently at that tag. In practice this would let a first-time PR
-# build overwrite the master image at :latest with its own content.
-images:
-- '$_IMAGE_TAG'


### PR DESCRIPTION
## Summary

Reworks `cloud-build-docker`'s `cloudbuild.yml` so the image digest it produces is a **pure function of build content** — two builds of identical sources yield the identical pushed digest.

BuildKit by default stamps the image config, per-step `history` entries, and file mtimes inside layers with wall-clock time, so byte-identical content produces a different digest on every build. Anything that pins images by digest (e.g. a Cloud Run job) then sees spurious "updates" on every rebuild.

## What changed

Switches from `docker build` to `docker buildx build` with the **docker-container driver**, and:

- `--build-arg SOURCE_DATE_EPOCH=0` — clamps the image config + `history[].created` timestamps
- `--output type=image,...,rewrite-timestamp=true` — clamps file mtimes *inside* the layer blobs (requires the docker-container driver; the default `docker` driver can't do it)
- `--provenance=false --sbom=false` — attestations embed build metadata (timestamps, build IDs) that is non-deterministic and would defeat the clamping
- `--cache-from type=registry` / `--cache-to type=inline` — replaces `docker pull` + the `BUILDKIT_INLINE_CACHE` build-arg; same branch-based layer caching
- `--output type=image,push=true` — replaces the `images:` block; only `$_IMAGE_TAG` is ever pushed (so no cache-tag clobber — supersedes the earlier clobber fix)

## Why the first commit wasn't enough

The first commit on this branch only added `--build-arg SOURCE_DATE_EPOCH=0`. Testing showed that clamps config/history timestamps but **not** layer file mtimes — two `--no-cache` builds still diverged (the `RUN`-layer blob differed). `rewrite-timestamp` is the missing piece, and it forces the `buildx` rework.

## Verification (local, Docker 29.4 / BuildKit)

| Build | Two builds → digest |
|---|---|
| Control (no flags) | differ |
| `SOURCE_DATE_EPOCH` build-arg only | still differ (layer mtimes) |
| `SOURCE_DATE_EPOCH` + `rewrite-timestamp` + `--provenance=false` | **identical** |
| + cache pruned & re-imported from registry | **identical**, 3 steps `CACHED` |

## Test plan

- [ ] Tag a release (e.g. `cloud-build-docker-v0.5.0`) after merge.
- [ ] Confirm `gcr.io/cloud-builders/docker` in Cloud Build provides `docker buildx` and that `docker buildx create --driver docker-container` works in that environment.
- [ ] Confirm `--output ...,push=true` from the docker-container builder authenticates to Artifact Registry (buildx forwards the docker CLI credentials).
- [ ] In a consumer repo, build the same source twice and confirm the manifest digest is identical, and that the runner terraform plan stops showing a recurring image-digest change.